### PR TITLE
Handle networkx and scipy dependencies in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,3 +11,5 @@ dependencies:
 # metagraph dependencies (so setup.py develop doesn't pip install them)
   - importlib_metadata
   - numpy
+  - networkx
+  - scipy


### PR DESCRIPTION
When running tests via `pytest`, I ran across a couple of errors that looked like the following:
```
================================================================================================================= ERRORS ==================================================================================================================
___________________________________________________________________________________ ERROR collecting metagraph/tests/algorithms/test_triangle_count.py ____________________________________________________________________________________
ImportError while importing test module '/Users/pnguyen/code/metagraph/metagraph/tests/algorithms/test_triangle_count.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
metagraph/tests/algorithms/test_triangle_count.py:1: in <module>
    import networkx as nx
E   ModuleNotFoundError: No module named 'networkx'
____________________________________________________________________________________ ERROR collecting metagraph/tests/translators/test_sparsematrix.py ____________________________________________________________________________________
ImportError while importing test module '/Users/pnguyen/code/metagraph/metagraph/tests/translators/test_sparsematrix.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
metagraph/tests/translators/test_sparsematrix.py:2: in <module>
    from metagraph.plugins.numpy.types import NumpySparseMatrix
metagraph/plugins/__init__.py:48: in <module>
    from . import graphblas, networkx, numpy, pandas, python, scipy
metagraph/plugins/scipy/__init__.py:1: in <module>
    from . import algorithms, translators, types
metagraph/plugins/scipy/algorithms.py:3: in <module>
    from .types import ScipyAdjacencyMatrix
E   ImportError: cannot import name 'ScipyAdjacencyMatrix' from 'metagraph.plugins.scipy.types' (/Users/pnguyen/code/metagraph/metagraph/plugins/scipy/types.py)
```

It looks like the `networkx` and `scipy` dependencies were missing from the `environment.yml`, so this commit adds them.

The attached `before.txt` and `after.txt` demonstrate how this change gets rid of a few of the errors. There are still issues with importing `GrblasMatrixType` that I intend to investigate further. 
[before.txt](https://github.com/ContinuumIO/metagraph/files/4319837/before.txt)
[after.txt](https://github.com/ContinuumIO/metagraph/files/4319836/after.txt)

