### PR TITLE
Add networkx and scipy and grblas dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,4 @@
 name: mg
-channels:
-  - jim22k
-
 dependencies:
 # dev environment
   - python=3.7
@@ -16,4 +13,4 @@ dependencies:
   - numpy
   - networkx
   - scipy
-  - grblas
+  - jim22k::grblas


### PR DESCRIPTION
This pull request builds upon that from https://github.com/ContinuumIO/metagraph/pull/23 .

When attempting to run tests via `pytest`, I encountered errors that looked like this:
```
================================================================================================================= ERRORS ==================================================================================================================
____________________________________________________________________________________ ERROR collecting metagraph/tests/translators/test_sparsematrix.py ____________________________________________________________________________________
ImportError while importing test module '/Users/pnguyen/code/metagraph/metagraph/tests/translators/test_sparsematrix.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
metagraph/tests/translators/test_sparsematrix.py:3: in <module>
    from metagraph.plugins.graphblas.types import GrblasMatrixType
E   ImportError: cannot import name 'GrblasMatrixType' from 'metagraph.plugins.graphblas.types' (/Users/pnguyen/code/metagraph/metagraph/plugins/graphblas/types.py)
____________________________________________________________________________________ ERROR collecting metagraph/tests/translators/test_sparsevector.py ____________________________________________________________________________________
ImportError while importing test module '/Users/pnguyen/code/metagraph/metagraph/tests/translators/test_sparsevector.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
metagraph/tests/translators/test_sparsevector.py:3: in <module>
    from metagraph.plugins.graphblas.types import GrblasVectorType
E   ImportError: cannot import name 'GrblasVectorType' from 'metagraph.plugins.graphblas.types' (/Users/pnguyen/code/metagraph/metagraph/plugins/graphblas/types.py)
```
This was due to a missing dependency on `grblas`.

These errors could be resolved with this command:
```
conda install -c jim22k grblas
```

This pull request entails changes to `environment.yml` that are intended to take care of this dependency on `grblas`.


I've attached before and after behavior that I'm getting. 
[before.txt](https://github.com/ContinuumIO/metagraph/files/4320341/before.txt)
[after.txt](https://github.com/ContinuumIO/metagraph/files/4320339/after.txt)