### PR TITLE
Fix tests test_subgraph.py and test_traversal.py

### DIFF
--- a/metagraph/tests/algorithms/test_subgraph.py
+++ b/metagraph/tests/algorithms/test_subgraph.py
@@ -1,3 +1,4 @@
+from metagraph.tests.util import default_plugin_resolver
 import networkx as nx
 from . import MultiVerify
 

--- a/metagraph/tests/algorithms/test_traversal.py
+++ b/metagraph/tests/algorithms/test_traversal.py
@@ -1,3 +1,4 @@
+from metagraph.tests.util import default_plugin_resolver
 import networkx as nx
 import numpy as np
 import scipy.sparse as ss


### PR DESCRIPTION
The import to grab the default plugin resolver was missing and was causing test failures.