### PR TITLE
Add tests for IndexedNodes & SequentialNodes __repr__ methods

### DIFF
--- a/metagraph/tests/test_node_index.py
+++ b/metagraph/tests/test_node_index.py
@@ -4,6 +4,11 @@ import pytest
 from metagraph.core.node_index import IndexedNodes, SequentialNodes
 
 
+def test_repr_methods():
+    assert isinstance(repr(IndexedNodes(np.array([1, 3, 5]))), str)
+    assert isinstance(repr(SequentialNodes(5)), str)
+
+
 def test_indexed_nodes():
     with pytest.raises(TypeError):
         IndexedNodes(np.array([[1, 2,], [3, 4]]))


### PR DESCRIPTION
Since we can't tell if anything'll error until we actually run the code, it's nice to have 100% test coverage even for trivial methods like the __repr__ methods of IndexedNodes & SequentialNodes.

This commit adds the test test_repr_methods that tests those methods to verify that they do not error.