### PR TITLE
Make PythonNodeMap.assert_equal not assume keys in props

### DIFF
--- a/metagraph/plugins/python/types.py
+++ b/metagraph/plugins/python/types.py
@@ -63,7 +63,7 @@ class PythonNodeMap(NodeMapWrapper, abstract=NodeMap):
     def assert_equal(cls, obj1, obj2, props1, props2, *, rel_tol=1e-9, abs_tol=0.0):
         assert props1 == props2, f"property mismatch: {props1} != {props2}"
         d1, d2 = obj1.value, obj2.value
-        if props1["dtype"] == "float":
+        if props1.get("dtype") == "float":
             assert (
                 not d1.keys() ^ d2.keys()
             ), f"Mismatched keys: {d1.keys() ^ d2.keys()}"


### PR DESCRIPTION
PythonNodeMap.assert_equal used to assume "dtype" was always a key in props. That's not always true. This commit gets rid of that assumption.