### PR TITLE
Add method PlanNamespace.num_translations

### DIFF
--- a/metagraph/core/planning.py
+++ b/metagraph/core/planning.py
@@ -34,11 +34,11 @@ class MultiStepTranslator:
         if self.unsatisfiable_dst_type is not None:
             s.append("[Unsatisfiable Translation]")
             s.append(
-                "Translation to {self.unsatisfiable_dst_type.__name__} unsatisfiable"
+                "Translation {self.src_type.__name__} -> {self.unsatisfiable_dst_type.__name__} unsatisfiable"
             )
         elif len(self) == 0:
             s.append("[Null Translation]")
-            s.append("No translation required")
+            s.append("No translation required from {self.src_type.__name__} to itself")
         elif len(self) > 1:
             s.append("[Multi-step Translation]")
             s.append(f"(start)  {self.src_type.__name__}")

--- a/metagraph/core/planning.py
+++ b/metagraph/core/planning.py
@@ -31,17 +31,16 @@ class MultiStepTranslator:
 
     def __repr__(self):
         s = []
-        s.append("[Multi-step Translation]")
-
         if self.unsatisfiable_dst_type is not None:
+            s.append("[Unsatisfiable Translation]")
             s.append(
                 "Translation to {self.unsatisfiable_dst_type.__name__} unsatisfiable"
             )
-
-        if len(self) == 0:
+        elif len(self) == 0:
+            s.append("[Null Translation]")
             s.append("No translation required")
-
-        if len(self) > 1:
+        elif len(self) > 1:
+            s.append("[Multi-step Translation]")
             s.append(f"(start)  {self.src_type.__name__}")
             for i, nxt_type in enumerate(self.dst_types[:-1]):
                 s.append(f"         {'  ' * i}  -> {nxt_type.__name__}")

--- a/metagraph/core/resolver.py
+++ b/metagraph/core/resolver.py
@@ -685,7 +685,7 @@ class Resolver:
         """Convert a value to a new concrete type using translators"""
         src_type = self.typeclass_of(value)
         translator = MultiStepTranslator.find_translation(self, src_type, dst_type)
-        if translator.unsatisfiable_dst_type is not None:
+        if translator.unsatisfiable:
             raise TypeError(f"Cannot convert {value} to {dst_type}")
         return translator(value, **props)
 

--- a/metagraph/core/resolver.py
+++ b/metagraph/core/resolver.py
@@ -685,7 +685,7 @@ class Resolver:
         """Convert a value to a new concrete type using translators"""
         src_type = self.typeclass_of(value)
         translator = MultiStepTranslator.find_translation(self, src_type, dst_type)
-        if translator.unsatisfiable:
+        if translator.unsatisfiable_dst_type is not None:
             raise TypeError(f"Cannot convert {value} to {dst_type}")
         return translator(value, **props)
 

--- a/metagraph/core/resolver.py
+++ b/metagraph/core/resolver.py
@@ -699,7 +699,7 @@ class Resolver:
         solutions: List[AlgorithmPlan] = []
         for concrete_algo in self.concrete_algorithms.get(algo_name, {}):
             plan = AlgorithmPlan.build(self, concrete_algo, *args, **kwargs)
-            if len(plan.build_problem_messages) == 0:
+            if not plan.unsatisfiable:
                 solutions.append(plan)
 
         # Sort by fewest number of translations required

--- a/metagraph/core/resolver.py
+++ b/metagraph/core/resolver.py
@@ -73,20 +73,33 @@ class PlanNamespace:
         self._resolver = resolver
         self.algos = Namespace()
 
-    def translate(self, value, dst_type, **props):
-        """
-        Print the steps taken to go from type of value to dst_type
-        """
+    def _get_translator(self, value, dst_type, **props):
         src_type = self._resolver.typeclass_of(value)
         translator = MultiStepTranslator.find_translation(
             self._resolver, src_type, dst_type
         )
+        return translator
+
+    def translate(self, value, dst_type, **props):
+        """
+        Print the steps taken to go from type of value to dst_type
+        """
+        translator = self._get_translator(value, dst_type, **props)
         if translator is None:
             print(
                 f"No translation path found for {src_type.__name__} -> {dst_type.__name__}"
             )
         else:
             translator.display()
+
+    def num_translations(self, value, dst_type, **props):
+        """
+        Return the number of translations needed to convert value to dst_type
+        """
+        translator = self._get_translator(value, dst_type, **props)
+        if translator is not None:
+            translator.display()
+        return float("inf") if translator is None else len(translator)
 
     def call_algorithm(self, algo_name: str, *args, **kwargs):
         valid_algos = self._resolver.find_algorithm_solutions(

--- a/metagraph/core/resolver.py
+++ b/metagraph/core/resolver.py
@@ -699,7 +699,7 @@ class Resolver:
         solutions: List[AlgorithmPlan] = []
         for concrete_algo in self.concrete_algorithms.get(algo_name, {}):
             plan = AlgorithmPlan.build(self, concrete_algo, *args, **kwargs)
-            if plan is not None:
+            if len(plan.build_problem_messages) == 0:
                 solutions.append(plan)
 
         # Sort by fewest number of translations required

--- a/metagraph/core/resolver.py
+++ b/metagraph/core/resolver.py
@@ -73,33 +73,15 @@ class PlanNamespace:
         self._resolver = resolver
         self.algos = Namespace()
 
-    def _get_translator(self, value, dst_type, **props):
+    def translate(self, value, dst_type, **props):
+        """
+        Return translator to translate from type of value to dst_type
+        """
         src_type = self._resolver.typeclass_of(value)
         translator = MultiStepTranslator.find_translation(
             self._resolver, src_type, dst_type
         )
         return translator
-
-    def translate(self, value, dst_type, **props):
-        """
-        Print the steps taken to go from type of value to dst_type
-        """
-        translator = self._get_translator(value, dst_type, **props)
-        if translator is None:
-            print(
-                f"No translation path found for {src_type.__name__} -> {dst_type.__name__}"
-            )
-        else:
-            translator.display()
-
-    def num_translations(self, value, dst_type, **props):
-        """
-        Return the number of translations needed to convert value to dst_type
-        """
-        translator = self._get_translator(value, dst_type, **props)
-        if translator is not None:
-            translator.display()
-        return float("inf") if translator is None else len(translator)
 
     def call_algorithm(self, algo_name: str, *args, **kwargs):
         valid_algos = self._resolver.find_algorithm_solutions(
@@ -703,7 +685,7 @@ class Resolver:
         """Convert a value to a new concrete type using translators"""
         src_type = self.typeclass_of(value)
         translator = MultiStepTranslator.find_translation(self, src_type, dst_type)
-        if translator is None:
+        if translator.unsatisfiable:
             raise TypeError(f"Cannot convert {value} to {dst_type}")
         return translator(value, **props)
 

--- a/metagraph/tests/algorithms/test_utility.py
+++ b/metagraph/tests/algorithms/test_utility.py
@@ -29,7 +29,7 @@ def test_nodeset_from_vector(default_plugin_resolver):
     )
 
 
-def test_nodeset_sort(default_plugin_resolver):
+def test_nodemap_sort(default_plugin_resolver):
     dpr = default_plugin_resolver
     py_node_map_unwrapped = {index: index * 100 for index in range(1, 8)}
     py_node_map = dpr.wrappers.NodeMap.PythonNodeMap(py_node_map_unwrapped)

--- a/metagraph/tests/test_resolver.py
+++ b/metagraph/tests/test_resolver.py
@@ -457,7 +457,7 @@ def test_find_translator(example_resolver):
         trns = MultiStepTranslator.find_translation(
             example_resolver, src_type, dst_type, exact=True
         )
-        if trns.unsatisfiable_dst_type is None:
+        if not trns.unsatisfiable:
             assert len(trns.translators) == 1
             return trns.translators[0]
 
@@ -492,9 +492,12 @@ def test_translate_plan(example_resolver):
     from .util import StrNum, OtherType
 
     translator = example_resolver.plan.translate(4, StrNum.Type)
+    assert not translator.unsatisfiable
+    assert translator.final_type == StrNum.Type
     assert len(translator) == 1
     translator = example_resolver.plan.translate(4, OtherType)
-    assert translator.unsatisfiable_dst_type == OtherType
+    assert translator.unsatisfiable
+    assert translator.final_type == OtherType
 
 
 def test_find_algorithm(example_resolver):

--- a/metagraph/tests/test_resolver.py
+++ b/metagraph/tests/test_resolver.py
@@ -457,7 +457,7 @@ def test_find_translator(example_resolver):
         trns = MultiStepTranslator.find_translation(
             example_resolver, src_type, dst_type, exact=True
         )
-        if not trns.unsatisfiable:
+        if trns.unsatisfiable_dst_type is None:
             assert len(trns.translators) == 1
             return trns.translators[0]
 
@@ -494,7 +494,7 @@ def test_translate_plan(example_resolver):
     translator = example_resolver.plan.translate(4, StrNum.Type)
     assert len(translator) == 1
     translator = example_resolver.plan.translate(4, OtherType)
-    assert translator.unsatisfiable
+    assert translator.unsatisfiable_dst_type == OtherType
 
 
 def test_find_algorithm(example_resolver):

--- a/metagraph/tests/test_resolver.py
+++ b/metagraph/tests/test_resolver.py
@@ -457,7 +457,7 @@ def test_find_translator(example_resolver):
         trns = MultiStepTranslator.find_translation(
             example_resolver, src_type, dst_type, exact=True
         )
-        if trns is not None:
+        if not trns.unsatisfiable:
             assert len(trns.translators) == 1
             return trns.translators[0]
 
@@ -488,16 +488,13 @@ def test_translate(example_resolver):
     assert example_resolver.translate(4, int) == 4
 
 
-def test_translate_plan(example_resolver, capsys):
+def test_translate_plan(example_resolver):
     from .util import StrNum, OtherType
 
-    capsys.readouterr()
-    example_resolver.plan.translate(4, StrNum.Type)
-    captured = capsys.readouterr()
-    assert captured.out == "[Direct Translation]\nIntType -> StrNumType\n"
-    example_resolver.plan.translate(4, OtherType)
-    captured = capsys.readouterr()
-    assert captured.out == "No translation path found for IntType -> OtherType\n"
+    translator = example_resolver.plan.translate(4, StrNum.Type)
+    assert len(translator) == 1
+    translator = example_resolver.plan.translate(4, OtherType)
+    assert translator.unsatisfiable
 
 
 def test_find_algorithm(example_resolver):


### PR DESCRIPTION
This commit adds `PlanNamespace.num_translations`, which returns the number of translations needed to translate a given instance of a type to a given type.

Currently, `PlanNamespace.translate` prints out the path and returns `None`. Knowing the number of steps in the path is useful for testing.