### PR TITLE
Remove documentation dependencies in CI environments

### DIFF
--- a/continuous_integration/environment-3.7.yml
+++ b/continuous_integration/environment-3.7.yml
@@ -6,15 +6,6 @@ dependencies:
   - pytest
   - pytest-cov
   - black
-  - conda-forge::pre-commit
-
-# documentation
-  - sphinx=3.0.4
-  - nbsphinx
-  - conda-forge::pydata-sphinx-theme
-  - pip
-  - pip:
-    - rst2pdf
 
 # metagraph dependencies (so setup.py develop doesn't pip install them)
   - importlib_metadata

--- a/continuous_integration/environment-3.8.yml
+++ b/continuous_integration/environment-3.8.yml
@@ -6,15 +6,6 @@ dependencies:
   - pytest
   - pytest-cov
   - black
-  - conda-forge::pre-commit
-
-# documentation
-  - sphinx=3.0.4
-  - nbsphinx
-  - conda-forge::pydata-sphinx-theme
-  - pip
-  - pip:
-    - rst2pdf
 
 # metagraph dependencies (so setup.py develop doesn't pip install them)
   - importlib_metadata

--- a/docs/getting_started/tutorial.ipynb
+++ b/docs/getting_started/tutorial.ipynb
@@ -276,7 +276,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g3.edges.show()"
+    "g3.edges"
    ]
   },
   {
@@ -508,7 +508,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The result is a `GrblasNodeMap`, which we can view easily with the `.show()` method on its underlying object."
+    "The result is a `GrblasNodeMap`, and we can easily view the underlying object."
    ]
   },
   {
@@ -517,7 +517,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pr.value.show()"
+    "pr.value"
    ]
   },
   {

--- a/metagraph/plugins/graphblas/types.py
+++ b/metagraph/plugins/graphblas/types.py
@@ -224,9 +224,6 @@ if has_grblas:
             self.value = data
             self.transposed = transposed
 
-        def show(self):
-            return self.value.show()
-
         class TypeMixin:
             @classmethod
             def _compute_abstract_properties(
@@ -275,9 +272,6 @@ if has_grblas:
             self._assert(data.nrows == data.ncols, "adjacency matrix must be square")
             self.value = data
             self.transposed = transposed
-
-        def show(self):
-            return self.value.show()
 
         class TypeMixin:
             @classmethod


### PR DESCRIPTION
This seems to save 20 seconds or so when resolving the environment.  These are non-essential packages for testing `metagraph`, so we should remove these dependencies from CI.