### PR TITLE
Add "include_resolver" flag for translators and algorithms

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include metagraph/_version.py
 recursive-include metagraph *.yaml
 include metagraph/tests/site_dir/plugin1-1.0.0.dist-info/entry_points.txt
 include metagraph/tests/bad_site_dir/bad_plugin-1.0.0.dist-info/entry_points.txt
+include metagraph/tests/bad_site_dir2/bad_plugin-1.0.0.dist-info/entry_points.txt

--- a/docs/getting_started/tutorial.ipynb
+++ b/docs/getting_started/tutorial.ipynb
@@ -276,7 +276,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g3.edges.show()"
+    "g3.edges.value"
    ]
   },
   {
@@ -508,7 +508,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The result is a `GrblasNodeMap`, which we can view easily with the `.show()` method on its underlying object."
+    "The result is a `GrblasNodeMap` whose values can be inspected by looking at the underlying `.value`."
    ]
   },
   {
@@ -517,7 +517,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pr.value.show()"
+    "pr.value"
    ]
   },
   {

--- a/docs/user_guide/algorithms.rst
+++ b/docs/user_guide/algorithms.rst
@@ -81,6 +81,20 @@ concrete type and return.
 *Open issue:* How to add custom parameters that can be passed when calling exact algorithms?
 
 
+Using the Resolver in Concrete Algorithms
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If a concrete algorithm needs access to the ``Resolver`` object which called it,
+set the ``include_resolver`` flag in the decorator and include a ``resolver`` keyword argument
+in the signature.
+
+.. code-block:: python
+
+    @concrete_algorithm("path.to.algorithm", include_resolver=True)
+    def my_conc_algo(x: NumpyNodeMap, *, resolver) -> int:
+        # resolver is now available
+
+
 Union and Optional types
 ------------------------
 

--- a/docs/user_guide/translators.rst
+++ b/docs/user_guide/translators.rst
@@ -31,6 +31,19 @@ The primary rule of translators is that translation can only happen
 between objects of the same abstract type. There are exceptions to this rule,
 but this is the main usage of translators in Metagraph.
 
+Using the Resolver in a Translator
+----------------------------------
+
+If a translator ever needs access to the `Resolver` object which called it,
+set the `include_resolver` flag in the decorator and include a "resolver" keyword argument
+in the signature.
+
+.. code-block:: python
+
+    @translator(include_resolver=True)
+    def my_translator(x: NumpyNodeMap, *, resolver, **props) -> MyCustomNodeMap:
+        # resolver is now available
+
 Unambiguous Subcomponents
 -------------------------
 

--- a/docs/user_guide/translators.rst
+++ b/docs/user_guide/translators.rst
@@ -34,8 +34,8 @@ but this is the main usage of translators in Metagraph.
 Using the Resolver in a Translator
 ----------------------------------
 
-If a translator ever needs access to the `Resolver` object which called it,
-set the `include_resolver` flag in the decorator and include a "resolver" keyword argument
+If a translator ever needs access to the ``Resolver`` object which called it,
+set the ``include_resolver`` flag in the decorator and include a ``resolver`` keyword argument
 in the signature.
 
 .. code-block:: python

--- a/metagraph/algorithms/bipartite.py
+++ b/metagraph/algorithms/bipartite.py
@@ -4,4 +4,4 @@ from metagraph.types import Graph, BipartiteGraph
 
 @abstract_algorithm("bipartite.graph_projection")
 def graph_projection(bgraph: BipartiteGraph, nodes_retained: int = 0) -> Graph:
-    pass
+    pass  # pragma: no cover

--- a/metagraph/algorithms/clustering.py
+++ b/metagraph/algorithms/clustering.py
@@ -32,7 +32,7 @@ def collapse_by_label(
     labels: NodeMap,
     aggregator: Callable[[Any, Any], Any],
 ) -> Graph:
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("cluster.triangle_count")

--- a/metagraph/algorithms/subgraph.py
+++ b/metagraph/algorithms/subgraph.py
@@ -4,9 +4,9 @@ from metagraph.types import NodeSet, Graph
 
 @abstract_algorithm("subgraph.extract_subgraph")
 def extract_subgraph(graph: Graph, nodes: NodeSet) -> Graph:
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("subgraph.k_core")
 def k_core(graph: Graph(is_directed=False), k: int) -> Graph:
-    pass
+    pass  # pragma: no cover

--- a/metagraph/algorithms/traversal.py
+++ b/metagraph/algorithms/traversal.py
@@ -8,7 +8,7 @@ def bellman_ford(
     graph: Graph(edge_type="map", edge_dtype={"int", "float"}), source_node: NodeID
 ) -> Tuple[NodeMap, NodeMap]:
     """Output is (Parents, Distance)"""
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("traversal.all_pairs_shortest_paths")
@@ -16,7 +16,7 @@ def all_pairs_shortest_paths(
     graph: Graph(edge_type="map", edge_dtype={"int", "float"})
 ) -> Tuple[Graph, Graph]:
     """Output is (Parents, Distance)"""
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("traversal.bfs_iter")
@@ -24,7 +24,7 @@ def breadth_first_search_iterator(
     graph: Graph, source_node: NodeID, depth_limit: int = -1
 ) -> Vector:
     """Output is NodeID"""
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("traversal.bfs_tree")
@@ -32,7 +32,7 @@ def breadth_first_search_tree(
     graph: Graph, source_node: NodeID, depth_limit: int = -1
 ) -> Tuple[NodeMap, NodeMap]:
     """Output is (Depth, Parents)"""
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("traversal.dijkstra")
@@ -43,4 +43,4 @@ def dijkstra(
     source_node: NodeID,
 ) -> Tuple[NodeMap, NodeMap]:
     """Output is (Parents, Distance)"""
-    pass
+    pass  # pragma: no cover

--- a/metagraph/algorithms/utility.py
+++ b/metagraph/algorithms/utility.py
@@ -6,44 +6,44 @@ from typing import Any, Callable
 
 @abstract_algorithm("util.nodeset.choose_random")
 def nodeset_choose_random(x: NodeSet, k: int) -> NodeSet:
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("util.nodeset.from_vector")
 def nodeset_from_vector(x: Vector) -> NodeSet:
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("util.nodemap.sort")
 def nodemap_sort(
     x: NodeMap, ascending: bool = True, limit: mg.Optional[int] = None
 ) -> Vector:
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("util.nodemap.select")
 def nodemap_select(x: NodeMap, nodes: NodeSet) -> NodeMap:
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("util.nodemap.filter")
 def nodemap_filter(x: NodeMap, func: Callable[[Any], bool]) -> NodeSet:
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("util.nodemap.apply")
 def nodemap_apply(x: NodeMap, func: Callable[[Any], Any]) -> NodeMap:
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("util.nodemap.reduce")
 def nodemap_reduce(x: NodeMap, func: Callable[[Any, Any], Any]) -> Any:
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("util.edge_map.from_edgeset")
 def edge_map_from_edgeset(edgeset: EdgeSet, default_value: Any,) -> EdgeMap:
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("util.graph.aggregate_edges")
@@ -59,7 +59,7 @@ def graph_aggregate_edges(
     if the graph is undirected and either in_edges == True or out_edges == True, we aggregate over all of the edges for each node exactly once to avoid double counting
     if the graph is directed, in_edges and out_edges specify which edge types to aggregate over for a given node
     """
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("util.graph.filter_edges")
@@ -70,7 +70,7 @@ def graph_filter_edges(
     func takes the edge weight and returns a bool
     Edges are removed, but nodes are kept (this may result in orphan nodes).
     """
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("util.graph.assign_uniform_weight")
@@ -80,7 +80,7 @@ def graph_assign_uniform_weight(
     """
     Make all the edge weights of a (possibly unweighted) have uniform magnitude.
     """
-    pass
+    pass  # pragma: no cover
 
 
 @abstract_algorithm("util.graph.build")
@@ -88,4 +88,4 @@ def graph_build(
     edges: mg.Union[EdgeSet, EdgeMap],
     nodes: mg.Optional[mg.Union[NodeSet, NodeMap]] = None,
 ) -> Graph:
-    pass
+    pass  # pragma: no cover

--- a/metagraph/core/planning.py
+++ b/metagraph/core/planning.py
@@ -49,7 +49,7 @@ class MultiStepTranslator:
         self.translators.append(translator)
         self.dst_types.append(dst_type)
 
-    def __call__(self, src, **props):
+    def __call__(self, src, *, resolver=None, **props):
         if not self.translators:
             return src
 
@@ -57,9 +57,9 @@ class MultiStepTranslator:
             self.display()
 
         for translator in self.translators[:-1]:
-            src = translator(src)
+            src = translator(src, resolver=resolver)
         # Finish by reaching destination along with required properties
-        dst = self.translators[-1](src, **props)
+        dst = self.translators[-1](src, resolver=resolver, **props)
         return dst
 
     def display(self):
@@ -186,7 +186,7 @@ class AlgorithmPlan:
         bound_args.apply_defaults()
         for varname in self.required_translations:
             bound_args.arguments[varname] = self.required_translations[varname](
-                bound_args.arguments[varname]
+                bound_args.arguments[varname], resolver=self.resolver
             )
         return self.algo(*bound_args.args, **bound_args.kwargs)
 

--- a/metagraph/core/plugin.py
+++ b/metagraph/core/plugin.py
@@ -2,6 +2,7 @@
 """
 import types
 import inspect
+from functools import partial
 from typing import Callable, List, Dict, Set, Any
 from .typecache import TypeCache, TypeInfo
 
@@ -393,6 +394,8 @@ class Wrapper(metaclass=MetaWrapper):
     The auto-created ConcreteType will be attached as `.Type` onto the wrapper class.
     """
 
+    _resolver = None
+
     def __init_subclass__(cls, *, abstract=None, register=True):
         if not register:
             cls._abstract = abstract
@@ -420,6 +423,9 @@ class Wrapper(metaclass=MetaWrapper):
         cls.Type.__doc__ = cls.__doc__
         # Point new Type class at this wrapper
         cls.Type.value_type = cls
+
+    def __init__(self):
+        pass
 
     @staticmethod
     def _assert_instance(obj, klass, err_msg=None):
@@ -453,31 +459,41 @@ class Translator:
     """Converts from one concrete type to another, enforcing properties on the
     destination if requested."""
 
-    def __init__(self, func: Callable):
+    def __init__(self, func: Callable, include_resolver: bool):
         self.func = func
+        self._include_resolver = include_resolver
         self.__name__ = func.__name__
         self.__doc__ = func.__doc__
         self.__wrapped__ = func
 
-    def __call__(self, src, **props):
-        return self.func(src, **props)
+    def __call__(self, src, *, resolver=None, **props):
+        if self._include_resolver:
+            if resolver is None:
+                raise ValueError("`resolver` is None, but is required by translator")
+            return self.func(src, resolver=resolver, **props)
+        else:
+            return self.func(src, **props)
 
 
-def translator(func: Callable = None):
+def translator(func: Callable = None, *, include_resolver=False):
     """
     decorator which can be called as either:
     >>> @translator
-    >>> def myfunc(): ...
+    >>> def myfunc(x: FromType, **props) -> ToType: ...
 
     We also handle the format
     >>> @translate()
-    >>> def myfunc(): ...
+    >>> def myfunc(x: FromType, **props) -> ToType: ...
+
+    If the resolver is needed as part of the translator, use this format
+    >>> @translate(include_resolver=True)
+    >>> def myfunc(x: FromType, *, resolver, **props) -> ToType: ...
     """
     # FIXME: signature checks?
     if func is None:
-        return Translator
+        return partial(Translator, include_resolver=include_resolver)
     else:
-        return Translator(func)
+        return Translator(func, include_resolver=include_resolver)
 
 
 def normalize_type(t):

--- a/metagraph/core/resolver.py
+++ b/metagraph/core/resolver.py
@@ -683,7 +683,7 @@ class Resolver:
         translator = MultiStepTranslator.find_translation(self, src_type, dst_type)
         if translator.unsatisfiable:
             raise TypeError(f"Cannot convert {value} to {dst_type}")
-        return translator(value, resolver=self, **props)
+        return translator(value, **props)
 
     def find_algorithm_solutions(
         self, algo_name: str, *args, **kwargs

--- a/metagraph/core/resolver.py
+++ b/metagraph/core/resolver.py
@@ -23,10 +23,6 @@ from ..types import NodeID
 import numpy as np
 
 
-class ResolveFailureError(Exception):
-    pass
-
-
 class NamespaceError(Exception):
     pass
 
@@ -692,7 +688,7 @@ class Resolver:
         translator = MultiStepTranslator.find_translation(self, src_type, dst_type)
         if translator is None:
             raise TypeError(f"Cannot convert {value} to {dst_type}")
-        return translator(value, **props)
+        return translator(value, resolver=self, **props)
 
     def find_algorithm_solutions(
         self, algo_name: str, *args, **kwargs

--- a/metagraph/plugins/graphblas/algorithms.py
+++ b/metagraph/plugins/graphblas/algorithms.py
@@ -1,6 +1,6 @@
 from metagraph import concrete_algorithm, NodeID
 from metagraph.plugins import has_grblas
-from typing import Tuple, Iterable, Any
+from typing import Tuple, Iterable, Any, Union
 
 if has_grblas:
     import grblas as gb
@@ -12,7 +12,6 @@ if has_grblas:
         GrblasNodeSet,
         GrblasVectorType,
     )
-    from ..python.types import PythonNodeSet
 
     @concrete_algorithm("cluster.triangle_count")
     def grblas_triangle_count(graph: GrblasGraph) -> int:
@@ -64,3 +63,10 @@ if has_grblas:
             if err < N * tolerance:
                 break
         return GrblasNodeMap(r)
+
+    @concrete_algorithm("util.graph.build")
+    def grblas_graph_build(
+        edges: Union[GrblasEdgeSet, GrblasEdgeMap],
+        nodes: Union[GrblasNodeSet, GrblasNodeMap, None],
+    ) -> GrblasGraph:
+        return GrblasGraph(edges, nodes)

--- a/metagraph/plugins/graphblas/types.py
+++ b/metagraph/plugins/graphblas/types.py
@@ -74,6 +74,7 @@ if has_grblas:
 
     class GrblasNodeSet(NodeSetWrapper, abstract=NodeSet):
         def __init__(self, data):
+            super().__init__()
             self._assert_instance(data, grblas.Vector)
             self.value = data
 
@@ -111,6 +112,7 @@ if has_grblas:
 
     class GrblasNodeMap(NodeMapWrapper, abstract=NodeMap):
         def __init__(self, data):
+            super().__init__()
             self._assert_instance(data, grblas.Vector)
             self.value = data
 
@@ -215,17 +217,26 @@ if has_grblas:
             else:
                 assert obj1.isequal(obj2, check_dtype=True)
 
+    def find_active_nodes(m):
+        """
+        Given a grblas.Matrix, returns a list of the active nodes
+        Active nodes are defined as having an edge. i.e. non-orphan nodes
+        """
+        v = m.reduce_rows(grblas.monoid.any).new()
+        h = m.reduce_columns(grblas.monoid.any).new()
+        v << v.ewise_add(h, grblas.monoid.any)
+        idx, _ = v.to_values()
+        return list(idx)
+
     class GrblasEdgeSet(EdgeSetWrapper, abstract=EdgeSet):
         def __init__(
             self, data, transposed=False,
         ):
+            super().__init__()
             self._assert_instance(data, grblas.Matrix)
             self._assert(data.nrows == data.ncols, "adjacency matrix must be square")
             self.value = data
             self.transposed = transposed
-
-        def show(self):
-            return self.value.show()
 
         class TypeMixin:
             @classmethod
@@ -271,13 +282,11 @@ if has_grblas:
         def __init__(
             self, data, transposed=False,
         ):
+            super().__init__()
             self._assert_instance(data, grblas.Matrix)
             self._assert(data.nrows == data.ncols, "adjacency matrix must be square")
             self.value = data
             self.transposed = transposed
-
-        def show(self):
-            return self.value.show()
 
         class TypeMixin:
             @classmethod

--- a/metagraph/plugins/networkx/translators.py
+++ b/metagraph/plugins/networkx/translators.py
@@ -1,21 +1,58 @@
 from metagraph import translator
-from metagraph.plugins import has_pandas, has_networkx
+from metagraph.plugins import has_networkx, has_scipy
 
 
-if has_networkx and has_pandas:
+if has_networkx and has_scipy:
     import networkx as nx
+    import numpy as np
     from .types import NetworkXGraph
-    from ..pandas.types import PandasEdgeMap
+    from ..scipy.types import ScipyGraph
+    from ..numpy.types import NumpyNodeSet, NumpyNodeMap
 
-    # @translator
-    # def edgemap_from_pandas(x: PandasEdgeMap, **props) -> NetworkXGraph:
-    #     cur_props = PandasEdgeMap.Type.compute_abstract_properties(x, ["is_directed"])
-    #
-    #     if cur_props["is_directed"]:
-    #         out = nx.DiGraph()
-    #     else:
-    #         out = nx.Graph()
-    #
-    #     g = x.value[[x.src_label, x.dst_label, x.weight_label]]
-    #     out.add_weighted_edges_from(g.itertuples(index=False, name="WeightedEdge"))
-    #     return NetworkXGraph(out, edge_weight_label="weight",)
+    @translator
+    def graph_from_scipy(x: ScipyGraph, **props) -> NetworkXGraph:
+        from ..python.types import dtype_casting
+
+        aprops = ScipyGraph.Type.compute_abstract_properties(
+            x, {"is_directed", "edge_type", "edge_dtype"}
+        )
+
+        nx_graph = nx.from_scipy_sparse_matrix(
+            x.edges.value,
+            create_using=nx.DiGraph if aprops["is_directed"] else nx.Graph,
+            edge_attribute="weight",
+        )
+
+        if aprops["edge_type"] == "set":
+            # Remove weight attribute
+            for _, _, attr in nx_graph.edges(data=True):
+                del attr["weight"]
+        else:
+            caster = dtype_casting[aprops["edge_dtype"]]
+            for _, _, attr in nx_graph.edges(data=True):
+                attr["weight"] = caster(attr["weight"])
+
+        if x.edges.node_list is not None:
+            pos2id = dict(enumerate(x.edges.node_list))
+            nx.relabel_nodes(nx_graph, pos2id, False)
+
+        if x.nodes is not None:
+            if isinstance(x.nodes, NumpyNodeSet):
+                nx_graph.add_nodes_from(x.nodes)
+            elif isinstance(x.nodes, NumpyNodeMap):
+                # TODO make __iter__ a required method for NodeMap implementations or making __getitem__ handle sets of ids to simplify this sort of code
+                make_weight_dict = lambda weight: {"weight": weight}
+                if x.nodes.mask is not None:
+                    ids = np.flatnonzero(x.nodes.mask)
+                    attrs = map(make_weight_dict, x.nodes.value[x.nodes.mask])
+                    id2attr = dict(zip(ids, attrs))
+                elif x.nodes.id2pos is not None:
+                    id2attr = {
+                        node_id: make_weight_dict(x.nodes.value[pos])
+                        for node_id, pos in x.nodes.id2pos.items()
+                    }
+                else:
+                    id2attr = dict(enumerate(map(make_weight_dict, x.nodes.value)))
+                nx.set_node_attributes(nx_graph, id2attr, name="weight")
+
+        return NetworkXGraph(nx_graph)

--- a/metagraph/plugins/networkx/types.py
+++ b/metagraph/plugins/networkx/types.py
@@ -22,6 +22,7 @@ if has_networkx:
         def __init__(
             self, nx_graph, node_weight_label="weight", edge_weight_label="weight"
         ):
+            super().__init__()
             self.value = nx_graph
             self.node_weight_label = node_weight_label
             self.edge_weight_label = edge_weight_label
@@ -162,6 +163,7 @@ if has_networkx:
             :param node_weight_label:
             :param edge_weight_label:
             """
+            super().__init__()
             self.value = nx_graph
             self.node_weight_label = node_weight_label
             self.edge_weight_label = edge_weight_label

--- a/metagraph/plugins/numpy/types.py
+++ b/metagraph/plugins/numpy/types.py
@@ -7,6 +7,7 @@ from metagraph.wrappers import NodeSetWrapper, NodeMapWrapper
 
 class NumpyNodeSet(NodeSetWrapper, abstract=NodeSet):
     def __init__(self, node_ids=None, *, mask=None):
+        super().__init__()
         self.node_array = None
         self.node_set = None
         self.mask = None
@@ -107,6 +108,7 @@ class NumpyNodeSet(NodeSetWrapper, abstract=NodeSet):
 
 class NumpyVector(Wrapper, abstract=Vector):
     def __init__(self, data, mask=None):
+        super().__init__()
         self._assert_instance(data, np.ndarray)
         if len(data.shape) != 1:
             raise TypeError(f"Invalid number of dimensions: {len(data.shape)}")
@@ -192,6 +194,7 @@ class NumpyNodeMap(NodeMapWrapper, abstract=NodeMap):
         Provide either mask or node_ids, not both.
         If there are not missing nodes, mask and node_ids are not required.
         """
+        super().__init__()
         self._assert_instance(data, np.ndarray)
         if len(data.shape) != 1:
             raise TypeError(f"Invalid number of dimensions: {len(data.shape)}")
@@ -318,7 +321,7 @@ class NumpyNodeMap(NodeMapWrapper, abstract=NodeMap):
                 nodes1 = obj1.pos2id
             else:
                 vals1 = obj1.value
-                nodes1 = np.array([])
+                nodes1 = np.arange(len(vals1))
             # Standardize obj2
             if obj2.mask is not None:
                 vals2 = obj2.value[obj2.mask]
@@ -328,7 +331,7 @@ class NumpyNodeMap(NodeMapWrapper, abstract=NodeMap):
                 nodes2 = obj2.pos2id
             else:
                 vals2 = obj2.value
-                nodes2 = np.array([])
+                nodes2 = np.arange(len(vals2))
 
             # Compare
             assert len(nodes1) == len(
@@ -346,6 +349,7 @@ class NumpyNodeMap(NodeMapWrapper, abstract=NodeMap):
 
 class NumpyMatrix(Wrapper, abstract=Matrix):
     def __init__(self, data, mask=None):
+        super().__init__()
         if type(data) is np.matrix:
             data = np.array(data, copy=False)
         self._assert_instance(data, np.ndarray)

--- a/metagraph/plugins/pandas/translators.py
+++ b/metagraph/plugins/pandas/translators.py
@@ -1,6 +1,5 @@
 from metagraph import translator
 from metagraph.plugins import has_pandas, has_networkx, has_scipy
-import operator
 
 if has_pandas:
     from .types import PandasEdgeMap, PandasEdgeSet
@@ -16,7 +15,7 @@ if has_pandas and has_scipy:
     from ..scipy.types import ScipyEdgeMap, ScipyEdgeSet
 
     @translator
-    def scipy_edgemap_to_pandas_edgemap(x: ScipyEdgeMap, **props) -> PandasEdgeMap:
+    def edgemap_from_scipy(x: ScipyEdgeMap, **props) -> PandasEdgeMap:
         is_directed = ScipyEdgeMap.Type.compute_abstract_properties(x, {"is_directed"})[
             "is_directed"
         ]
@@ -31,30 +30,7 @@ if has_pandas and has_scipy:
         return PandasEdgeMap(df, is_directed=is_directed)
 
     @translator
-    def pandas_edgemap_to_scipy_edgemap(x: PandasEdgeMap, **props) -> ScipyEdgeMap:
-        is_directed = x.is_directed
-        node_list = pd.unique(x.value[[x.src_label, x.dst_label]].values.ravel("K"))
-        node_list.sort()
-        num_nodes = len(node_list)
-        id2pos = dict(map(reversed, enumerate(node_list)))
-        get_id_pos = lambda node_id: id2pos[node_id]
-        source_positions = x.value[x.src_label].map(get_id_pos)
-        target_positions = x.value[x.dst_label].map(get_id_pos)
-        weights = x.value[x.weight_label]
-        if not is_directed:
-            source_positions, target_positions = (
-                pd.concat([source_positions, target_positions]),
-                pd.concat([target_positions, source_positions]),
-            )
-            weights = pd.concat([weights, weights])
-        matrix = ss.coo_matrix(
-            (weights, (source_positions, target_positions)),
-            shape=(num_nodes, num_nodes),
-        ).tocsr()
-        return ScipyEdgeMap(matrix, node_list)
-
-    @translator
-    def scipy_edgeset_to_pandas_edgeset(x: ScipyEdgeSet, **props) -> PandasEdgeSet:
+    def edgeset_from_scipy(x: ScipyEdgeSet, **props) -> PandasEdgeSet:
         is_directed = ScipyEdgeSet.Type.compute_abstract_properties(x, {"is_directed"})[
             "is_directed"
         ]
@@ -67,45 +43,3 @@ if has_pandas and has_scipy:
             rc_pairs = filter(lambda pair: pair[0] < pair[1], rc_pairs)
         df = pd.DataFrame(rc_pairs, columns=["source", "target"])
         return PandasEdgeSet(df, is_directed=is_directed)
-
-    @translator
-    def pandas_edgeset_to_scipy_edgeset(x: PandasEdgeSet, **props) -> ScipyEdgeSet:
-        is_directed = x.is_directed
-        node_list = pd.unique(x.value[[x.src_label, x.dst_label]].values.ravel("K"))
-        node_list.sort()
-        num_nodes = len(node_list)
-        id2pos = dict(map(reversed, enumerate(node_list)))
-        get_id_pos = lambda node_id: id2pos[node_id]
-        source_positions = x.value[x.src_label].map(get_id_pos)
-        target_positions = x.value[x.dst_label].map(get_id_pos)
-        if not is_directed:
-            source_positions, target_positions = (
-                pd.concat([source_positions, target_positions]),
-                pd.concat([target_positions, source_positions]),
-            )
-        matrix = ss.coo_matrix(
-            (np.ones(len(source_positions)), (source_positions, target_positions)),
-            shape=(num_nodes, num_nodes),
-        ).tocsr()
-        return ScipyEdgeSet(matrix, node_list)
-
-
-if has_pandas and has_networkx:
-    from .types import PandasEdgeMap
-    import networkx as nx
-    from ..networkx.types import NetworkXGraph
-
-    # @translator
-    # def edgemap_from_networkx(x: NetworkXGraph, **props) -> PandasEdgeMap:
-    #     df = nx.convert_matrix.to_pandas_edgelist(
-    #         x.value, source="source", target="destination"
-    #     )
-    #     cols = ["source", "destination", x.weight_label]
-    #     df = df[cols]
-    #     return PandasEdgeMap(
-    #         df,
-    #         src_label="source",
-    #         dst_label="destination",
-    #         weight_label=x.weight_label,
-    #         is_directed=x.value.is_directed(),
-    #     )

--- a/metagraph/plugins/pandas/types.py
+++ b/metagraph/plugins/pandas/types.py
@@ -35,6 +35,7 @@ if has_pandas:
         def __init__(
             self, df, src_label="source", dst_label="target", *, is_directed=True
         ):
+            super().__init__()
             self._assert_instance(df, pd.DataFrame)
             self.value = df
             self.is_directed = is_directed
@@ -127,6 +128,7 @@ if has_pandas:
                                           will raise an error
             :param node_label:
             """
+            super().__init__()
             self._assert_instance(df, pd.DataFrame)
             self.value = df
             self.is_directed = is_directed

--- a/metagraph/plugins/python/types.py
+++ b/metagraph/plugins/python/types.py
@@ -12,6 +12,7 @@ class PythonNodeSet(NodeSetWrapper, abstract=NodeSet):
         """
         data: set of node ids
         """
+        super().__init__()
         self._assert_instance(data, set)
         self.value = data
 
@@ -50,6 +51,7 @@ class PythonNodeMap(NodeMapWrapper, abstract=NodeMap):
         """
         data: dict of node id: weight
         """
+        super().__init__()
         self._assert_instance(data, dict)
         self.value = data
 

--- a/metagraph/plugins/scipy/types.py
+++ b/metagraph/plugins/scipy/types.py
@@ -63,6 +63,7 @@ if has_scipy:
 
     class ScipyEdgeSet(EdgeSetWrapper, abstract=EdgeSet):
         def __init__(self, data, node_list=None, transposed=False):
+            super().__init__()
             self._assert_instance(data, ss.spmatrix)
             nrows, ncols = data.shape
             self._assert(nrows == ncols, "Adjacency Matrix must be square")
@@ -133,6 +134,7 @@ if has_scipy:
         def __init__(
             self, data, node_list=None, transposed=False,
         ):
+            super().__init__()
             self._assert_instance(data, ss.spmatrix)
             nrows, ncols = data.shape
             self._assert(nrows == ncols, "Adjacency Matrix must be square")

--- a/metagraph/tests/algorithms/__init__.py
+++ b/metagraph/tests/algorithms/__init__.py
@@ -152,6 +152,7 @@ class MultiVerify:
                     print(f"compare_val.value  {compare_val.value}")
                     print(f"expected_val       {expected_val}")
                     print(f"expected_val.value {expected_val.value}")
+                    # breakpoint()
                     raise
             except TypeError:
                 raise UnsatisfiableAlgorithmError(

--- a/metagraph/tests/algorithms/test_utility.py
+++ b/metagraph/tests/algorithms/test_utility.py
@@ -318,7 +318,7 @@ def test_graph_build(default_plugin_resolver):
     """
     graph_ss_matrix = ss.csr_matrix(
         np.array(
-            [[0, 3, 0, 1], [3, 0, 4, 9], [0, 4, 0, 2], [1, 9, 2, 0],], dtype=np.int64
+            [[0, 3, 0, 1], [3, 0, 4, 9], [0, 4, 0, 2], [1, 9, 2, 0]], dtype=np.int64
         )
     )
     edges = dpr.wrappers.EdgeMap.ScipyEdgeMap(graph_ss_matrix, [1, 3, 4, 5])
@@ -337,7 +337,7 @@ def test_graph_build(default_plugin_resolver):
     """
     graph_ss_matrix = ss.csr_matrix(
         np.array(
-            [[0, 3, 0, 1], [3, 0, 4, 9], [0, 4, 0, 2], [1, 9, 2, 0],], dtype=np.int64
+            [[0, 3, 0, 1], [3, 0, 4, 9], [0, 4, 0, 2], [1, 9, 2, 0]], dtype=np.int64
         )
     )
     edges = dpr.wrappers.EdgeMap.ScipyEdgeMap(graph_ss_matrix, [1, 3, 4, 5])
@@ -356,7 +356,7 @@ def test_graph_build(default_plugin_resolver):
 3(30) ------ 4(40)      0(99)
     """
     graph_ss_matrix = ss.csr_matrix(
-        np.array([[0, 1, 0, 1], [1, 0, 1, 1], [0, 1, 0, 1], [1, 1, 1, 0],], dtype=bool)
+        np.array([[0, 1, 0, 1], [1, 0, 1, 1], [0, 1, 0, 1], [1, 1, 1, 0]], dtype=bool)
     )
     edges = dpr.wrappers.EdgeSet.ScipyEdgeSet(graph_ss_matrix, [1, 3, 4, 5])
     node_map_data = np.array([99, 10, 99, 30, 40, 50])
@@ -374,7 +374,7 @@ def test_graph_build(default_plugin_resolver):
 3 ------ 4      0
     """
     graph_ss_matrix = ss.csr_matrix(
-        np.array([[0, 1, 0, 1], [1, 0, 1, 1], [0, 1, 0, 1], [1, 1, 1, 0],], dtype=bool)
+        np.array([[0, 1, 0, 1], [1, 0, 1, 1], [0, 1, 0, 1], [1, 1, 1, 0]], dtype=bool)
     )
     edges = dpr.wrappers.EdgeMap.ScipyEdgeMap(graph_ss_matrix, [1, 3, 4, 5])
     nodes = dpr.wrappers.NodeSet.NumpyNodeSet(node_ids=np.array([0, 1, 2, 3, 4, 5]))

--- a/metagraph/tests/bad_site_dir/bad_plugin-1.0.0.dist-info/entry_points.txt
+++ b/metagraph/tests/bad_site_dir/bad_plugin-1.0.0.dist-info/entry_points.txt
@@ -1,2 +1,2 @@
 [metagraph.plugins]
-incorrect_name = plugin1:find_plugins
+plugins = bad_plugin:find_plugins

--- a/metagraph/tests/bad_site_dir/bad_plugin.py
+++ b/metagraph/tests/bad_site_dir/bad_plugin.py
@@ -53,10 +53,12 @@ def gpu_supercluster(hg: GPUHyperGraph) -> GPUHyperGraph:  # pragma: no cover
 
 def find_plugins():
     return {
-        "abstract_types": {HyperGraphType},
-        "concrete_types": {CPUHyperGraphType},
-        "wrappers": {GPUHyperGraph},
-        "translators": {cpu_to_gpu_hypergraph, gpu_to_cpu_hypergraph},
-        "abstract_algorithms": {supercluster},
-        "concrete_algorithms": {cpu_supercluster, gpu_supercluster},
+        "plugin1": {
+            "abstract_types": {HyperGraphType},
+            "concrete_types": {CPUHyperGraphType},
+            "wrappers": {GPUHyperGraph},
+            "translators": {cpu_to_gpu_hypergraph, gpu_to_cpu_hypergraph},
+            "abstract_algorithms": {supercluster},
+            "concrete_algorithms": {cpu_supercluster, gpu_supercluster},
+        }
     }

--- a/metagraph/tests/bad_site_dir2/bad_plugin-1.0.0.dist-info/entry_points.txt
+++ b/metagraph/tests/bad_site_dir2/bad_plugin-1.0.0.dist-info/entry_points.txt
@@ -1,0 +1,2 @@
+[metagraph.plugins]
+incorrect_name = bad_plugin:find_plugins

--- a/metagraph/tests/test_entrypoints.py
+++ b/metagraph/tests/test_entrypoints.py
@@ -13,13 +13,13 @@ from metagraph.core.plugin import (
 )
 
 
-from .util import site_dir, bad_site_dir
+from .util import site_dir, bad_site_dir, bad_site_dir2
 
 
 ABSTRACT_KINDS = {
     "abstract_types": (issubclass, AbstractType),
     "abstract_algorithms": (isinstance, AbstractAlgorithm),
-    "concrete_types": (isinstance, ConcreteAlgorithm),
+    "concrete_algorithms": (isinstance, ConcreteAlgorithm),
     "concrete_types": (issubclass, ConcreteType),
     "wrappers": (issubclass, Wrapper),
     "translators": (isinstance, Translator),
@@ -35,6 +35,11 @@ def test_load_registry(site_dir):
             assert test_func(obj, kind_class)
 
 
-def test_load_failure(bad_site_dir):
+def test_load_duplicate_name(site_dir, bad_site_dir):
+    with pytest.raises(ValueError, match="plugin1 already registered"):
+        metagraph.core.entrypoints.load_plugins()
+
+
+def test_load_bad_entrypoint_name(bad_site_dir2):
     with pytest.raises(metagraph.core.entrypoints.EntryPointsError):
         plugins = metagraph.core.entrypoints.load_plugins()

--- a/metagraph/tests/test_plugin.py
+++ b/metagraph/tests/test_plugin.py
@@ -49,7 +49,7 @@ def test_abstract_type():
         class ConcreteType1(
             plugin.ConcreteType, abstract=AbstractType1(k1="bad_k1_value")
         ):
-            pass
+            pass  # pragma: no cover
 
 
 def test_concrete_type():
@@ -141,14 +141,16 @@ def test_wrapper():
         plugin.Wrapper, abstract=MyNumericAbstractType
     ):
         def __init__(self, val):
-            self.value = val
+            super().__init__()
             self._assert_instance(val, str)
-            self._assert(0 == float(val), "'zero' is only valid value.")
-            assert isinstance(val, str)
+            self._assert(0 == float(val), "str '0' is the only valid value.")
 
         class TypeMixin:
             pass
 
+    # This should work
+    StrNumZeroOnlyDefaultErrorMessage("0")
+    # This will fail
     with pytest.raises(TypeError, match="is not an instance of"):
         StrNumZeroOnlyDefaultErrorMessage(0)
 

--- a/metagraph/tests/test_resolver.py
+++ b/metagraph/tests/test_resolver.py
@@ -249,7 +249,7 @@ def test_union_signatures():
         e: typing.Optional[typing.Union[Abstract1, Abstract2]],
         f: typing.Optional[Abstract2],
     ) -> int:
-        pass
+        pass  # pragma: no cover
 
     @abstract_algorithm("testing.mg_union_types")
     def mg_union_types(
@@ -260,7 +260,7 @@ def test_union_signatures():
         e: mg.Optional[mg.Union[Abstract1, Abstract2]],
         f: mg.Optional[Abstract2],
     ) -> int:
-        pass
+        pass  # pragma: no cover
 
     @abstract_algorithm("testing.mg_union_instances")
     def mg_union_instances(
@@ -268,7 +268,7 @@ def test_union_signatures():
         b: mg.Optional[mg.Union[Abstract1(), Abstract2()]],
         c: mg.Optional[Abstract2()],
     ) -> int:
-        pass
+        pass  # pragma: no cover
 
     registry = PluginRegistry("test_union_signatures_good")
     registry.register(Abstract1)
@@ -281,13 +281,13 @@ def test_union_signatures():
     res_good.register(registry.plugins)
 
     @abstract_algorithm("testing.typing_union_mixed")
-    def typing_union_mixed(a: typing.Union[int, Abstract1]) -> int:
+    def typing_union_mixed(a: typing.Union[int, Abstract1]) -> int:  # pragma: no cover
         pass
 
     with pytest.raises(TypeError, match="Cannot mix"):
 
         @abstract_algorithm("testing.mg_union_mixed")
-        def mg_union_mixed(a: mg.Union[int, Abstract1]) -> int:
+        def mg_union_mixed(a: mg.Union[int, Abstract1]) -> int:  # pragma: no cover
             pass
 
     registry = PluginRegistry("test_union_signatures_bad")
@@ -482,10 +482,19 @@ def test_translate(example_resolver):
     def int_to_int(src: int, **props) -> int:  # pragma: no cover
         return src
 
+    @translator(include_resolver=True)
+    def float_to_float_resolver(
+        src: float, *, resolver, **props
+    ) -> float:  # pragma: no cover
+        assert isinstance(resolver, Resolver)
+        return src
+
     registry = PluginRegistry("test_translate_default_plugin")
     registry.register(int_to_int)
+    registry.register(float_to_float_resolver)
     example_resolver.register(registry.plugins)
     assert example_resolver.translate(4, int) == 4
+    assert example_resolver.translate(4.4, float) == 4.4
 
 
 def test_translate_plan(example_resolver):
@@ -656,7 +665,9 @@ def test_plugin_specific_concrete_algorithms():
                     getattr(plugin_tree, plugin_tree_name),
                 )
         else:
-            raise ValueError(f"Unexpected type {type(resolver_tree)}")
+            raise ValueError(
+                f"Unexpected type {type(resolver_tree)}"
+            )  # pragma: no cover
         return
 
     tree_names = [
@@ -718,15 +729,15 @@ def test_duplicate_plugin():
 
     @abstract_algorithm("test_duplciate_plugin.test_abstract_algo")
     def abstract_algo1(input_int: int):
-        pass
+        pass  # pragma: no cover
 
     @concrete_algorithm("test_duplciate_plugin.test_abstract_algo")
     def concrete_algo1(input_int: int):
-        pass
+        pass  # pragma: no cover
 
     @concrete_algorithm("test_duplciate_plugin.test_abstract_algo")
     def concrete_algo2(input_int: int):
-        pass
+        pass  # pragma: no cover
 
     res = Resolver()
     with pytest.raises(
@@ -814,17 +825,17 @@ def test_wrapper_insufficient_properties():
     class TestNodes(AbstractType):
         @Wrapper.required_method
         def __getitem__(self, label):
-            raise NotImplementedError()
+            raise NotImplementedError()  # pragma: no cover
 
         @Wrapper.required_property
         def num_nodes(self):
-            raise NotImplementedError()
+            raise NotImplementedError()  # pragma: no cover
 
     with pytest.raises(TypeError, match="is missing required wrapper method"):
 
         class Wrapper1(Wrapper, abstract=TestNodes):
             def num_nodes(self):
-                return "dummy"
+                return "dummy"  # pragma: no cover
 
             class TypeMixin:
                 pass
@@ -833,7 +844,7 @@ def test_wrapper_insufficient_properties():
 
         class Wrapper1(Wrapper, abstract=TestNodes):
             def __getitem__(self, label):
-                return "dummy"
+                return "dummy"  # pragma: no cover
 
             class TypeMixin:
                 pass
@@ -844,7 +855,7 @@ def test_wrapper_insufficient_properties():
             num_nodes = "string that is not a property or function"
 
             def __getitem__(self, label):
-                return "dummy"
+                return "dummy"  # pragma: no cover
 
             class TypeMixin:
                 pass
@@ -853,19 +864,19 @@ def test_wrapper_insufficient_properties():
 def test_algorithm_versions():
     @abstract_algorithm("test_algorithm_versions.test_abstract_algo")
     def abstract_algo1(input_int: int):
-        pass
+        pass  # pragma: no cover
 
     @abstract_algorithm("test_algorithm_versions.test_abstract_algo", version=1)
     def abstract_algo2(input_int: int):
-        pass
+        pass  # pragma: no cover
 
     @concrete_algorithm("test_algorithm_versions.test_abstract_algo")
     def concrete_algo1(input_int: int):
-        pass
+        pass  # pragma: no cover
 
     @concrete_algorithm("test_algorithm_versions.test_abstract_algo", version=1)
     def concrete_algo2(input_int: int):
-        pass
+        pass  # pragma: no cover
 
     # Sanity check
     res = Resolver()

--- a/metagraph/tests/test_types.py
+++ b/metagraph/tests/test_types.py
@@ -3,11 +3,31 @@ import pytest
 from metagraph import types
 
 
+def test_nodeset_not_implemented():
+    nodeset = types.NodeSet()
+
+    with pytest.raises(NotImplementedError):
+        0 in nodeset
+
+    with pytest.raises(NotImplementedError):
+        nodeset.num_nodes()
+
+
 def test_nodemap_not_implemented():
     nodemap = types.NodeMap()
+
+    with pytest.raises(NotImplementedError):
+        0 in nodemap
 
     with pytest.raises(NotImplementedError):
         nodemap[0]
 
     with pytest.raises(NotImplementedError):
         nodemap.num_nodes()
+
+
+def test_node_id():
+    assert str(types.NodeID) == "NodeID"
+
+    with pytest.raises(NotImplementedError):
+        types.NodeID(25)

--- a/metagraph/tests/types/test_vector.py
+++ b/metagraph/tests/types/test_vector.py
@@ -48,8 +48,8 @@ def test_numpy():
     NumpyVector.Type.assert_equal(
         NumpyVector(np.array([1, 2, 3, 4]), mask=np.array([True, False, True, False])),
         NumpyVector(np.array([1, 2, 3, 22]), mask=np.array([True, False, True, False])),
-        {},
-        {},
+        {"dtype": "bool", "is_dense": False},
+        {"dtype": "bool", "is_dense": False},
         {},
         {},
     )

--- a/metagraph/tests/util.py
+++ b/metagraph/tests/util.py
@@ -27,6 +27,11 @@ def bad_site_dir():
     yield from make_site_dir_fixture("bad_site_dir")
 
 
+@pytest.fixture
+def bad_site_dir2():
+    yield from make_site_dir_fixture("bad_site_dir2")
+
+
 class MyAbstractType(plugin.AbstractType):
     pass
 
@@ -80,7 +85,7 @@ class StrNum(plugin.Wrapper, abstract=MyNumericAbstractType):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return NotImplemented
+            return NotImplemented  # pragma: no cover
         return self.value == other.value
 
     class TypeMixin:

--- a/metagraph/wrappers.py
+++ b/metagraph/wrappers.py
@@ -42,6 +42,7 @@ class GraphWrapper(Wrapper, abstract=Graph, register=False):
 
 class CompositeGraphWrapper(GraphWrapper, abstract=Graph, register=False):
     def __init__(self, edges, nodes=None):
+        super().__init__()
         self.value = (edges, nodes)
         self.edges = edges
         self.nodes = nodes


### PR DESCRIPTION
Translators can receive the resolver by passing `include_resolver=True` to the decorator. Concrete algorithms can likewise receive the resolver by passing `include_resolver=True` to the decorator.

``` python
@translator(include_resolver=True)
def my_translator(x: InputType, *, resolver, **props) -> OutputType:
    # do something with `resolver`
    pass

@concrete_algorithm('path.to.abst.algorithm', include_resolver=True)
def my_algo(x: InputType, *, resolver, other_kwarg=True) -> int:
    # do something with `resolver`
    return 42
```

I also added several translators to enable the CompositeGraph translators to delegate to their components.

Additionally, I improved test coverage in several places.