### PR TITLE
Dask integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
 script:
     - black --check --diff metagraph
     - pytest
+    - pytest --dask --cov-append
     - conda build -c defaults -c conda-forge --python ${TRAVIS_PYTHON_VERSION} continuous_integration/conda
     - conda install -c conda-forge coveralls
     - coveralls

--- a/conftest.py
+++ b/conftest.py
@@ -7,3 +7,8 @@ def pytest_addoption(parser):
         action="store_true",
         help="Exclude plugins when running algorithm tests.",
     )
+    parser.addoption(
+        "--dask",
+        action="store_true",
+        help="Use a DaskResolver instead of the normal Resolver.",
+    )

--- a/continuous_integration/conda/meta.yaml
+++ b/continuous_integration/conda/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - scipy
     - donfig
     - grblas
+    - dask
 
 test:
   requires:

--- a/continuous_integration/environment-3.7.yml
+++ b/continuous_integration/environment-3.7.yml
@@ -16,3 +16,4 @@ dependencies:
   - scipy
   - conda-forge::donfig
   - conda-forge::grblas
+  - dask

--- a/continuous_integration/environment-3.8.yml
+++ b/continuous_integration/environment-3.8.yml
@@ -16,3 +16,4 @@ dependencies:
   - scipy
   - conda-forge::donfig
   - conda-forge::grblas
+  - dask

--- a/environment.yml
+++ b/environment.yml
@@ -26,3 +26,4 @@ dependencies:
   - scipy
   - conda-forge::donfig
   - conda-forge::grblas
+  - dask

--- a/metagraph/core/dask/__init__.py
+++ b/metagraph/core/dask/__init__.py
@@ -1,0 +1,1 @@
+from .resolver import DaskResolver

--- a/metagraph/core/dask/__init__.py
+++ b/metagraph/core/dask/__init__.py
@@ -1,1 +1,0 @@
-from .resolver import DaskResolver

--- a/metagraph/core/dask/placeholder.py
+++ b/metagraph/core/dask/placeholder.py
@@ -82,3 +82,22 @@ class Placeholder(DaskMethodsMixin):
             # Add this func to the task graph (no need for apply)
             dsk[key] = (func,) + tuple(new_args)
         return cls(key, dsk)
+
+
+class DelayedWrapper:
+    def __init__(self, klass, placeholder):
+        self._klass = klass
+        self._ph = placeholder
+
+    def __call__(self, *args, **kwargs):
+        key = (
+            f"init-{tokenize(self._ph, self._klass, args, kwargs)}",
+            self._klass.__name__,
+        )
+        return self._ph.build(key, self._klass, args, kwargs)
+
+    def __repr__(self):
+        return f"DelayedWrapper<{self._ph.concrete_type.__name__}>"
+
+    def __getattr__(self, item):
+        return getattr(self._klass, item)

--- a/metagraph/core/dask/placeholder.py
+++ b/metagraph/core/dask/placeholder.py
@@ -1,3 +1,4 @@
+import types
 import dask
 from dask import is_dask_collection
 from dask.base import DaskMethodsMixin, tokenize
@@ -32,6 +33,10 @@ def finalize(collection):
 
 
 class Placeholder(DaskMethodsMixin):
+    """
+    Acts as a stand-in for the actual `value_type` of a ConcreteType in a delayed context
+    """
+
     concrete_type = None  # subclasses should override this
     __dask_scheduler__ = staticmethod(dask.threaded.get)
 
@@ -85,6 +90,12 @@ class Placeholder(DaskMethodsMixin):
 
 
 class DelayedWrapper:
+    """
+    Wraps a class constructor and returns the indicated Placeholder when called.
+    This allows for delayed construction of objects which know the eventual type,
+    enabling translations and algorithm calls using the delayed object as input.
+    """
+
     def __init__(self, klass, placeholder):
         self._klass = klass
         self._ph = placeholder

--- a/metagraph/core/dask/placeholder.py
+++ b/metagraph/core/dask/placeholder.py
@@ -1,0 +1,83 @@
+import dask
+from dask import is_dask_collection
+from dask.base import DaskMethodsMixin, tokenize
+from dask.core import quote
+from dask.highlevelgraph import HighLevelGraph
+
+
+def single_key(seq):
+    return seq[0]
+
+
+def rebuild(dsk, cls, key):
+    return cls(key, dsk)
+
+
+def ph_apply(func, args, kwargs):
+    return func(*args, **kwargs)
+
+
+def finalize(collection):
+    assert is_dask_collection(collection)
+
+    if isinstance(collection, Placeholder):
+        return collection._key, collection._dsk
+
+    name = "finalize-" + tokenize(collection)
+    keys = collection.__dask_keys__()
+    finalize, args = collection.__dask_postcompute__()
+    layer = {name: (finalize, keys) + args}
+    graph = HighLevelGraph.from_collections(name, layer, dependencies=[collection])
+    return name, graph
+
+
+class Placeholder(DaskMethodsMixin):
+    __dask_scheduler__ = staticmethod(dask.threaded.get)
+
+    def __init__(self, key, dsk=None):
+        self._key = key
+        if dsk is None:
+            dsk = {}
+        self._dsk = dsk
+
+    def __dask_graph__(self):
+        return self._dsk
+
+    def __dask_keys__(self):
+        return [self._key]
+
+    def __dask_tokenize__(self):
+        return self._key
+
+    def __dask_postcompute__(self):
+        return single_key, ()
+
+    def __dask_postpersist__(self):
+        return rebuild, (self.__class__, self._key)
+
+    @classmethod
+    def build(cls, key, func, args, kwargs=None):
+        dsk = {}
+        new_args = []
+        for arg in args:
+            if is_dask_collection(arg):
+                arg, graph = finalize(arg)
+                dsk.update(graph)
+            else:
+                arg = quote(arg)
+            new_args.append(arg)
+        if kwargs:
+            new_kwargs_flat = []
+            for kw, val in kwargs.items():
+                if is_dask_collection(val):
+                    val, graph = finalize(val)
+                    dsk.update(graph)
+                else:
+                    val = quote(val)
+                new_kwargs_flat.append([kw, val])
+            # Add this func to the task graph
+            dsk[key] = (ph_apply, func, new_args, (dict, new_kwargs_flat))
+        else:
+            # Add this func to the task graph (no need for apply)
+            dsk[key] = (func,) + tuple(new_args)
+        return cls(key, dsk)

--- a/metagraph/core/dask/placeholder.py
+++ b/metagraph/core/dask/placeholder.py
@@ -32,6 +32,7 @@ def finalize(collection):
 
 
 class Placeholder(DaskMethodsMixin):
+    concrete_type = None  # subclasses should override this
     __dask_scheduler__ = staticmethod(dask.threaded.get)
 
     def __init__(self, key, dsk=None):

--- a/metagraph/core/dask/resolver.py
+++ b/metagraph/core/dask/resolver.py
@@ -1,0 +1,104 @@
+import types
+from dask.base import tokenize
+from dask import delayed
+from ..resolver import Resolver, PlanNamespace
+from .placeholder import Placeholder
+from ..plugin import ConcreteType
+
+
+class DaskResolver:
+    _placeholders = {}
+
+    def __init__(self, resolver: Resolver):
+        self._resolver = resolver
+
+        # Patch plan namespace
+        self.plan = PlanNamespace(self)
+        self.plan.algos = self._resolver.plan.algos
+
+        # Add placeholder types to `class_to_concrete`
+        self.class_to_concrete = self._resolver.class_to_concrete.copy()
+        for ct in self._resolver.concrete_types:
+            ph = self._get_placeholder(ct)
+            self.class_to_concrete[ph] = ct
+
+    # Default behavior (unless overridden) is to delegate to the original resolver
+    def __getattr__(self, item):
+        return getattr(self._resolver, item)
+
+    def __dir__(self):
+        return dir(self._resolver)
+
+    def _get_placeholder(self, concrete_type):
+        if concrete_type not in self._placeholders:
+            ph = types.new_class(f"{concrete_type.__name__}Placeholder", (Placeholder,))
+            self._placeholders[concrete_type] = ph
+        return self._placeholders[concrete_type]
+
+    def _add_translation_plan(self, mst, src, **props):
+        obj = src
+        src_type = mst.src_type
+        for trans, dst_type in zip(mst.translators, mst.dst_types):
+            ph = self._get_placeholder(dst_type)
+            key = f"translate::{src_type.__name__}->{dst_type.__name__}::{tokenize(ph, trans, obj, props)}"
+            if dst_type is mst.final_type:
+                obj = ph.build(key, trans, (obj,), props)
+            else:
+                obj = ph.build(key, trans, (obj,))
+            src_type = dst_type
+        return obj
+
+    def _add_algorithm_plan(self, algo_plan, *args, **kwargs):
+        sig = algo_plan.algo.__signature__
+        # Walk through arguments and apply required translations
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+        for name, val in bound.arguments.items():
+            if name in algo_plan.required_translations:
+                trans = algo_plan.required_translations[name]
+                bound.arguments[name] = self._add_translation_plan(trans, val)
+        args, kwargs = bound.args, bound.kwargs
+        # Determine return type and add task
+        ret = sig.return_annotation
+        if getattr(ret, "__origin__", None) == tuple:
+            # TODO: how do we handle multiple return types?
+            raise NotImplementedError(
+                "Currently can't handle delayed calls which return multiple objects"
+            )
+        elif type(ret) is not type and isinstance(ret, ConcreteType):
+            ct = type(ret)
+            ph = self._get_placeholder(ct)
+            key = f"algorithm::{algo_plan.algo.abstract_name}::{tokenize(ph, algo_plan, args, kwargs)}"
+            return ph.build(key, algo_plan, args, kwargs)
+        else:
+            # Use dask.delayed instead of a Placeholder
+            delayed_call = delayed(algo_plan)
+            key = f"algorithm::{algo_plan.algo.abstract_name}::{tokenize(delayed_call, algo_plan, args, kwargs)}"
+            return delayed_call(*args, **kwargs, dask_key_name=key)
+
+    def register(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Register with the resolver prior to creating a DaskResolver"
+        )
+
+    def assert_equal(self, *args, **kwargs):
+        raise NotImplementedError("Do not assert_equal with a DaskResolver")
+
+    def typeclass_of(self, value):
+        """Return the concrete typeclass corresponding to a value"""
+        # Check for direct lookup
+        concrete_type = self.class_to_concrete.get(type(value))
+        if concrete_type is None:
+            for ct in self.concrete_types:
+                if ct.is_typeclass_of(value):
+                    concrete_type = ct
+                    break
+            else:
+                raise TypeError(
+                    f"Class {value.__class__} does not have a registered type"
+                )
+        return concrete_type
+
+    def translate(self, value, dst_type, **props):
+        translator = self.plan.translate(value, dst_type, **props)
+        return self._add_translation_plan(translator, value, **props)

--- a/metagraph/core/dask/resolver.py
+++ b/metagraph/core/dask/resolver.py
@@ -64,9 +64,29 @@ class DaskResolver:
         return obj
 
     def __dir__(self):
-        return dir(self._resolver)
+        names = dir(self._resolver) + ["delayed_wrapper"]
+        names.sort()
+        return names
 
     def delayed_wrapper(self, klass, concrete_type: Optional[ConcreteType] = None):
+        """
+        Similar to how `dask.delayed` operates by wrapping a callable, but
+        in this case, the callable must be a class which is a type of a ConcreteType.
+
+        For example, a `grblas.Vector` is the `value_class` of `GrblasVectorType`.
+        To build a delayed `grblas.Vector` object and have Metagraph understand that it
+        is of type `GrblasVectorType`, wrap the constructor using `delayed_wrapper`.
+        >>> dvec = delayed_resolver.delayed_wrapper(grblas.Vector.from_values)
+        >>> my_vec = dvec([0, 1, 2], [2.2, 3.3, 9.9])
+        >>> my_vec
+        <types.GrblasVectorTypePlaceholder at 0x7f93e488b450>
+
+        This delayed object can now be passed to translators and algorithms and
+        Metagraph will know its type and build the lazy dispatch graph correctly.
+
+        Attempting to translate normal `dask.delayed` objects or pass them to an
+        algorithm will yield an unsatisfiable result.
+        """
         ct = concrete_type
         if ct is None:
             ct = self._resolver.class_to_concrete.get(klass)
@@ -78,6 +98,19 @@ class DaskResolver:
         return DelayedWrapper(klass, ph)
 
     def _get_placeholder(self, concrete_type):
+        """
+        A placeholder is a class which behaves like the `value_type` of `concrete_type`, but is delayed.
+        The placeholder class name will always be semething like "NumpyEdgeMapTypePlaceholder" with the
+        name "Placeholder" immediately following the full concrete type name.
+
+        Many places in Metagraph, the resolver needs to consult its `class_to_concrete` dictionary to
+        know which ConcreteType an object belongs to. These placeholder objects are registered with the
+        dask resolver in `class_to_concrete` so the lookups behave correctly.
+
+        Having the `class_to_concrete` lookups function allows translation and algorithm calling to work
+        on delayed objects. The delayed task graph can be built up because the concrete type of each
+        operation is know beforehand by way of placeholders.
+        """
         if concrete_type not in self._placeholders:
             ph = types.new_class(f"{concrete_type.__name__}Placeholder", (Placeholder,))
             ph.concrete_type = concrete_type
@@ -85,6 +118,9 @@ class DaskResolver:
         return self._placeholders[concrete_type]
 
     def _add_translation_plan(self, mst, src, **props):
+        """
+        Given a translation plan, decompose its pieces and add each step to the task graph.
+        """
         obj = src
         src_type = mst.src_type
         for trans, dst_type in zip(mst.translators, mst.dst_types):
@@ -104,6 +140,10 @@ class DaskResolver:
         return obj
 
     def _add_algorithm_plan(self, algo_plan, *args, **kwargs):
+        """
+        Given an algorithm plan, decompose it into individual translations and the actual
+        function call, adding a task to the task graph for each piece.
+        """
         args, kwargs = algo_plan.apply_abstract_defaults(
             self._resolver, algo_plan.algo.abstract_name, *args, **kwargs
         )
@@ -174,6 +214,9 @@ class DaskResolver:
 
     def translate(self, value, dst_type, **props):
         trans_plan = self.plan.translate(value, dst_type, **props)
+        # Calling the plan will trigger a call to `_add_translation_plan`.
+        #   The MultiStepTranslator knows about and checks for a DaskResolver
+        #   when the plan is called.
         return trans_plan(value, **props)
 
     def call_algorithm(self, algo_name: str, *args, **kwargs):
@@ -185,4 +228,7 @@ class DaskResolver:
         else:
             # choose the solutions requiring the fewest translations
             plan = valid_algos[0]
+            # Calling the plan will trigger a call to `_add_algorithm_plan`.
+            #   The AlgorithmPlan knows about and checks for a DaskResolver
+            #   when the plan is called.
             return plan(*args, **kwargs)

--- a/metagraph/core/dask/resolver.py
+++ b/metagraph/core/dask/resolver.py
@@ -142,24 +142,8 @@ class DaskResolver:
             obj2 = obj2.compute()
         self._resolver.assert_equal(obj1, obj2, rel_tol=rel_tol, abs_tol=abs_tol)
 
-    def typeclass_of(self, value):
-        """Return the concrete typeclass corresponding to a value"""
-        # Check for direct lookup
-        concrete_type = self.class_to_concrete.get(type(value))
-        if concrete_type is None:
-            for ct in self.concrete_types:
-                if ct.is_typeclass_of(value):
-                    concrete_type = ct
-                    break
-            else:
-                raise TypeError(
-                    f"Class {value.__class__} does not have a registered type within the DaskResolver"
-                )
-        return concrete_type
-
     def translate(self, value, dst_type, **props):
         trans_plan = self.plan.translate(value, dst_type, **props)
-        # return self._add_translation_plan(trans_plan, value, **props)
         return trans_plan(value, **props)
 
     def call_algorithm(self, algo_name: str, *args, **kwargs):
@@ -171,5 +155,4 @@ class DaskResolver:
         else:
             # choose the solutions requiring the fewest translations
             plan = valid_algos[0]
-            # return self._add_algorithm_plan(plan, *args, **kwargs)
             return plan(*args, **kwargs)

--- a/metagraph/core/planning.py
+++ b/metagraph/core/planning.py
@@ -20,14 +20,14 @@ class MultiStepTranslator:
     def __len__(self):
         if self.unsatisfiable:
             raise ValueError(
-                "No translation path found for {src_type.__name__} -> {self.final_type.__name__}"
+                f"No translation path found for {self.src_type.__name__} -> {self.final_type.__name__}"
             )
         return len(self.translators)
 
     def __iter__(self):
         if self.unsatisfiable:
             raise ValueError(
-                "No translation path found for {src_type.__name__} -> {self.final_type.__name__}"
+                f"No translation path found for {self.src_type.__name__} -> {self.final_type.__name__}"
             )
         return iter(self.translators)
 
@@ -36,12 +36,12 @@ class MultiStepTranslator:
         if self.unsatisfiable:
             s.append("[Unsatisfiable Translation]")
             s.append(
-                "Translation {self.src_type.__name__} -> {self.final_type.__name__} unsatisfiable"
+                f"Translation {self.src_type.__name__} -> {self.final_type.__name__} unsatisfiable"
             )
         elif len(self) == 0:
             s.append("[Null Translation]")
             s.append(
-                "No translation required from {self.src_type.__name__} -> {self.final_type.__name__}"
+                f"No translation required from {self.src_type.__name__} -> {self.final_type.__name__}"
             )
         elif len(self) > 1:
             s.append("[Multi-step Translation]")
@@ -68,7 +68,7 @@ class MultiStepTranslator:
     def __call__(self, src, **props):
         if self.unsatisfiable:
             raise ValueError(
-                "No translation path found for {src_type.__name__} -> {self.final_type.__name__}"
+                f"No translation path found for {self.src_type.__name__} -> {self.final_type.__name__}"
             )
 
         if not self.translators:

--- a/metagraph/core/planning.py
+++ b/metagraph/core/planning.py
@@ -97,8 +97,7 @@ class MultiStepTranslator:
     def find_translation(
         cls, resolver, src_type, dst_type, *, exact=False
     ) -> "MultiStepTranslator":
-        if isinstance(dst_type, type) and not issubclass(dst_type, ConcreteType):
-            dst_type = resolver.class_to_concrete.get(dst_type, dst_type)
+        dst_type = resolver.class_to_concrete.get(dst_type, dst_type)
 
         if not isinstance(dst_type, type):
             dst_type = dst_type.__class__

--- a/metagraph/core/resolver.py
+++ b/metagraph/core/resolver.py
@@ -98,8 +98,8 @@ class PlanNamespace:
             Dispatcher(self._resolver, algo_name).signatures
         else:
             # choose the solutions requiring the fewest translations
-            algo = valid_algos[0]
-            return algo.display()
+            plan = valid_algos[0]
+            return plan
 
     @property
     def abstract_algorithms(self):

--- a/metagraph/dask.py
+++ b/metagraph/dask.py
@@ -1,5 +1,5 @@
 import metagraph as mg
-from .core.dask import DaskResolver
+from .core.dask.resolver import DaskResolver
 
 # Wrap the default resolver as a DaskResolver
 resolver = DaskResolver(mg.resolver)

--- a/metagraph/dask.py
+++ b/metagraph/dask.py
@@ -1,0 +1,8 @@
+import metagraph as mg
+from .core.dask import DaskResolver
+
+# Wrap the default resolver as a DaskResolver
+resolver = DaskResolver(mg.resolver)
+
+
+del mg

--- a/metagraph/tests/algorithms/__init__.py
+++ b/metagraph/tests/algorithms/__init__.py
@@ -2,6 +2,7 @@ from typing import Union, AnyStr, Callable, Tuple
 import math
 from metagraph import ConcreteType
 from metagraph.core.resolver import Resolver, Dispatcher
+from dask import is_dask_collection
 
 
 class UnsatisfiableAlgorithmError(Exception):
@@ -91,6 +92,8 @@ class MultiVerify:
                         )
 
                 try:
+                    if is_dask_collection(ret_val):
+                        ret_val = ret_val.compute()
                     cmp_func(ret_val)
                 except Exception:
                     print("Performing custom compare against:")
@@ -139,6 +142,9 @@ class MultiVerify:
         if issubclass(expected_type, ConcreteType):
             try:
                 compare_val = self.resolver.translate(ret_val, type(expected_val))
+                if is_dask_collection(compare_val):
+                    compare_val = compare_val.compute()
+
                 try:
                     if not expected_type.is_typeclass_of(compare_val):
                         raise TypeError(

--- a/metagraph/tests/algorithms/test_flow.py
+++ b/metagraph/tests/algorithms/test_flow.py
@@ -1,4 +1,5 @@
 from metagraph.tests.util import default_plugin_resolver
+import metagraph as mg
 import networkx as nx
 from . import MultiVerify
 from typing import Tuple
@@ -51,7 +52,7 @@ v /      v /      v v
     nx_graph_answer = nx.DiGraph()
     nx_graph_answer.add_weighted_edges_from(ebunch_answer)
     expected_flow_value = 6
-    expected_graph = dpr.wrappers.Graph.NetworkXGraph(nx_graph_answer)
+    expected_graph = mg.plugins.networkx.types.NetworkXGraph(nx_graph_answer)
 
     def cmp_func(x):
         actual_flow_value, actual_flow_graph = x

--- a/metagraph/tests/test_dask.py
+++ b/metagraph/tests/test_dask.py
@@ -6,8 +6,12 @@ from metagraph.tests.util import default_plugin_resolver
 from metagraph.plugins.python.types import PythonNodeMap
 from metagraph.plugins.numpy.types import NumpyNodeMap
 from metagraph.plugins.graphblas.types import GrblasNodeMap
+from metagraph.plugins.networkx.types import NetworkXGraph
+from metagraph.plugins.scipy.types import ScipyGraph
+from metagraph.plugins.scipy.algorithms import ss_graph_filter_edges
+from metagraph.plugins.networkx.algorithms import nx_graph_aggregate_edges
 import grblas
-import dask
+import networkx as nx
 
 
 def test_translation_direct(default_plugin_resolver):
@@ -53,3 +57,57 @@ def test_translation_multistep(default_plugin_resolver):
     assert isinstance(z, Placeholder)
     assert len(z._dsk.keys()) == 2  # Only one translation, but creates two tasks
     ldpr.assert_equal(z, final)
+
+
+def test_algo_chain(default_plugin_resolver):
+    dpr = default_plugin_resolver
+    res_small = Resolver()
+    # Only register some of the translators to force a multi-step translation path
+    res_small.register(
+        {
+            "foo": {
+                "abstract_types": dpr.abstract_types,
+                "concrete_types": dpr.concrete_types,
+                "wrappers": {PythonNodeMap, NumpyNodeMap, GrblasNodeMap},
+                "translators": {
+                    dpr.translators[(PythonNodeMap.Type, NumpyNodeMap.Type)],
+                    dpr.translators[(NumpyNodeMap.Type, GrblasNodeMap.Type)],
+                    dpr.translators[(NetworkXGraph.Type, ScipyGraph.Type)],
+                    dpr.translators[(ScipyGraph.Type, NetworkXGraph.Type)],
+                },
+                "abstract_algorithms": set(dpr.abstract_algorithms.values()),
+                "concrete_algorithms": {
+                    nx_graph_aggregate_edges,
+                    ss_graph_filter_edges,
+                },
+            }
+        }
+    )
+    ldpr = DaskResolver(res_small)
+    g = nx.Graph()
+    g.add_weighted_edges_from(
+        [(0, 1, 1), (0, 2, 2), (0, 3, 3), (0, 4, 4), (2, 4, 5), (3, 4, 6)]
+    )
+    graph = NetworkXGraph(g)
+    sum_of_all_edges = PythonNodeMap({0: 10, 1: 1, 2: 7, 3: 9, 4: 15})
+    sum_of_filtered_edges = PythonNodeMap({0: 7, 1: 0, 2: 5, 3: 9, 4: 15})
+    # Verify simple algorithm call works (no translations required)
+    nm = ldpr.algos.util.graph.aggregate_edges(
+        graph, lambda x, y: x + y, initial_value=0
+    )
+    assert isinstance(nm, Placeholder)
+    assert nm.concrete_type is PythonNodeMap.Type
+    assert len(nm._dsk.keys()) == 1
+    ldpr.assert_equal(nm, sum_of_all_edges)
+    # Build chained algo call with translators
+    graph2 = ldpr.algos.util.graph.filter_edges(graph, lambda x: x > 2)
+    assert isinstance(graph2, Placeholder)
+    assert graph2.concrete_type is ScipyGraph.Type
+    assert len(graph2._dsk.keys()) == 2
+    nm2 = ldpr.algos.util.graph.aggregate_edges(
+        graph2, lambda x, y: x + y, initial_value=0
+    )
+    assert isinstance(nm2, Placeholder)
+    assert nm2.concrete_type is PythonNodeMap.Type
+    assert len(nm2._dsk.keys()) == 4  # translate, filter, translate, aggregate
+    ldpr.assert_equal(nm2, sum_of_filtered_edges)

--- a/metagraph/tests/test_dask.py
+++ b/metagraph/tests/test_dask.py
@@ -1,0 +1,52 @@
+import pytest
+from metagraph.core.resolver import Resolver
+from metagraph.core import dask as mgdask
+from metagraph.tests.util import default_plugin_resolver
+from metagraph.plugins.python.types import PythonNodeMap
+from metagraph.plugins.numpy.types import NumpyNodeMap
+from metagraph.plugins.graphblas.types import GrblasNodeMap
+import grblas
+
+
+def test_translation_direct(default_plugin_resolver):
+    dpr = default_plugin_resolver
+    ldpr = mgdask.DaskResolver(dpr)
+    x = PythonNodeMap({0: 12.5, 1: 33.4, 42: -1.2})
+    final = GrblasNodeMap(
+        grblas.Vector.from_values([0, 1, 42], [12.5, 33.4, -1.2], size=43),
+    )
+    y = ldpr.translate(x, NumpyNodeMap)
+    z = ldpr.translate(y, GrblasNodeMap)
+    assert isinstance(y, mgdask.placeholder.Placeholder)
+    assert isinstance(z, mgdask.placeholder.Placeholder)
+    assert len(y._dsk.keys()) == 1  # Only one task to perform
+    assert len(z._dsk.keys()) == 2  # Two tasks to perform because y is still lazy
+    dpr.assert_equal(z.compute(), final)
+
+
+def test_translation_multistep(default_plugin_resolver):
+    dpr = default_plugin_resolver
+    res_small = Resolver()
+    # Only register some of the translators to force a multi-step translation path
+    res_small.register(
+        {
+            "foo": {
+                "abstract_types": dpr.abstract_types,
+                "concrete_types": dpr.concrete_types,
+                "wrappers": {PythonNodeMap, NumpyNodeMap, GrblasNodeMap},
+                "translators": {
+                    dpr.translators[(PythonNodeMap.Type, NumpyNodeMap.Type)],
+                    dpr.translators[(NumpyNodeMap.Type, GrblasNodeMap.Type)],
+                },
+            }
+        }
+    )
+    ldpr = mgdask.DaskResolver(res_small)
+    x = PythonNodeMap({0: 12.5, 1: 33.4, 42: -1.2})
+    final = GrblasNodeMap(
+        grblas.Vector.from_values([0, 1, 42], [12.5, 33.4, -1.2], size=43),
+    )
+    z = ldpr.translate(x, GrblasNodeMap)
+    assert isinstance(z, mgdask.placeholder.Placeholder)
+    assert len(z._dsk.keys()) == 2  # Only one translation, but creates two tasks
+    dpr.assert_equal(z.compute(), final)

--- a/metagraph/tests/test_resolver.py
+++ b/metagraph/tests/test_resolver.py
@@ -570,10 +570,10 @@ def test_call_algorithm(example_resolver):
 
 def test_call_algorithm_plan(example_resolver, capsys):
     capsys.readouterr()
-    example_resolver.plan.call_algorithm("power", 2, 3)
-    captured = capsys.readouterr()
-    assert "int_power" in captured.out
-    assert "Argument Translations" in captured.out
+    plan = example_resolver.plan.call_algorithm("power", 2, 3)
+    text = repr(plan)
+    assert "int_power" in text
+    assert "Argument Translations" in text
     example_resolver.plan.call_algorithm("power", 2, "4")
     captured = capsys.readouterr()
     assert (

--- a/metagraph/tests/translators/test_node_map.py
+++ b/metagraph/tests/translators/test_node_map.py
@@ -86,6 +86,9 @@ def test_numpy_graphblas(default_plugin_resolver):
     x = NumpyNodeMap(data, mask=~missing)
     assert x.num_nodes == 3
     # Convert numpy -> graphblas
-    intermediate = GrblasNodeMap(grblas.Vector.from_values([2, 4, 6], [3, 4, -1]),)
-    y = dpr.translate(x, GrblasNodeMap)
+    intermediate = dpr.wrappers.NodeMap.GrblasNodeMap(
+        grblas.Vector.from_values([2, 4, 6], [3, 4, -1]),
+    )
+    # NOTE: this tests DelayedWrappers in dask mode in addition to the normal translation
+    y = dpr.translate(x, dpr.wrappers.NodeMap.GrblasNodeMap)
     dpr.assert_equal(y, intermediate)

--- a/metagraph/tests/util.py
+++ b/metagraph/tests/util.py
@@ -242,4 +242,10 @@ def default_plugin_resolver(request):  # pragma: no cover
         res.register(**find_plugins())
     else:
         res.load_plugins_from_environment()
+
+    if request.config.getoption("--dask", default=False):
+        from metagraph.dask import DaskResolver
+
+        res = DaskResolver(res)
+
     return res

--- a/metagraph/wrappers.py
+++ b/metagraph/wrappers.py
@@ -43,7 +43,6 @@ class GraphWrapper(Wrapper, abstract=Graph, register=False):
 class CompositeGraphWrapper(GraphWrapper, abstract=Graph, register=False):
     def __init__(self, edges, nodes=None):
         super().__init__()
-        self.value = (edges, nodes)
         self.edges = edges
         self.nodes = nodes
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - numpy
     - scipy
     - donfig
+    - dask
 
 test:
   requires:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description="Graph algorithm solver across multiple hardware backends",
     author="Anaconda, Inc.",
     packages=find_packages(include=["metagraph", "metagraph.*"]),
-    install_requires=["importlib_metadata", "numpy", "scipy", "donfig"],
+    install_requires=["importlib_metadata", "numpy", "scipy", "donfig", "dask"],
     include_package_data=True,
     entry_points={"metagraph.plugins": ["plugins=metagraph.plugins:find_plugins",]},
 )


### PR DESCRIPTION
This will give you a DaskResolver object wrapping the default `mg.resolver`.
```python
from metagraph.dask import resolver
```
Use it as you would the normal resolver, but returned objects are dask objects, requiring `.compute()`.

To wrap you own custom resolver, use:
```python
from metagraph.dask import DaskResolver
lazy = DaskResolver(my_custom_resolver)
```

Calling algorithms and calling `.translate` will return `Placeholder` objects for each ConcreteType. This allows the system to know the input type when choosing translators and concrete algorithms.

Translations as part of an algorithm call and multi-step translations are converted into separate dask tasks.

Tests now have a `--dask` calling option which will run all tests using a `DaskResolver`.