### PR TITLE
Max flow and minimum spanning tree concrete algorithms for NetworkX and Scipy plugins

### DIFF
--- a/metagraph/algorithms/__init__.py
+++ b/metagraph/algorithms/__init__.py
@@ -1,8 +1,9 @@
 from . import (
     bipartite,
+    centrality,
     clustering,
+    flow,
     subgraph,
     traversal,
-    centrality,
     utility,
 )

--- a/metagraph/algorithms/flow.py
+++ b/metagraph/algorithms/flow.py
@@ -1,6 +1,7 @@
 import metagraph as mg
 from metagraph import abstract_algorithm
 from metagraph.types import Graph, NodeID, EdgeMap
+from typing import Tuple
 
 
 @abstract_algorithm("flow.max_flow")
@@ -8,5 +9,6 @@ def max_flow(
     graph: Graph(edge_type="map", edge_dtype={"int", "float"}),
     source_node: NodeID,
     target_node: NodeID,
-) -> EdgeMap:
+) -> Tuple[float, Graph]:
+    """The returned graph is a graph whose edge weights represent the outward flow. It contains all the nodes of the input graph"""
     pass  # pragma: no cover

--- a/metagraph/algorithms/flow.py
+++ b/metagraph/algorithms/flow.py
@@ -1,0 +1,12 @@
+import metagraph as mg
+from metagraph import abstract_algorithm
+from metagraph.types import Graph, NodeID, EdgeMap
+
+
+@abstract_algorithm("flow.max_flow")
+def max_flow(
+    graph: Graph(edge_type="map", edge_dtype={"int", "float"}),
+    source_node: NodeID,
+    target_node: NodeID,
+) -> EdgeMap:
+    pass  # pragma: no cover

--- a/metagraph/algorithms/traversal.py
+++ b/metagraph/algorithms/traversal.py
@@ -44,3 +44,11 @@ def dijkstra(
 ) -> Tuple[NodeMap, NodeMap]:
     """Output is (Parents, Distance)"""
     pass  # pragma: no cover
+
+
+@abstract_algorithm("traversal.minimum_spanning_tree")
+def minimum_spanning_tree(
+    graph: Graph(is_directed=False, edge_type="map", edge_dtype={"int", "float"})
+) -> Graph(is_directed=False, edge_type="map", edge_dtype={"int", "float"}):
+    """If the graph is disconnected, a minimum spanning forest is returned."""  # TODO consider renaming this to minimum_spanning_forest
+    pass  # pragma: no cover

--- a/metagraph/plugins/networkx/algorithms.py
+++ b/metagraph/plugins/networkx/algorithms.py
@@ -171,6 +171,26 @@ if has_networkx:
             edge_weight_label=bgraph.edge_weight_label,
         )
 
+    @concrete_algorithm("flow.max_flow")
+    def nx_max_flow(
+        graph: NetworkXGraph, source_node: NodeID, target_node: NodeID,
+    ) -> Tuple[float, NetworkXGraph]:
+        flow_value, flow_dict = nx.maximum_flow(
+            graph.value, source_node, target_node, capacity=graph.edge_weight_label
+        )
+        nx_flow_graph = nx.DiGraph()
+        for src in flow_dict.keys():
+            for dst in flow_dict[src].keys():
+                nx_flow_graph.add_edge(
+                    src, dst, **{graph.edge_weight_label: flow_dict[src][dst]}
+                )
+        flow_graph = NetworkXGraph(
+            nx_flow_graph,
+            node_weight_label=graph.node_weight_label,
+            edge_weight_label=graph.edge_weight_label,
+        )
+        return (flow_value, flow_graph)
+
     @concrete_algorithm("util.graph.aggregate_edges")
     def nx_graph_aggregate_edges(
         graph: NetworkXGraph,

--- a/metagraph/plugins/networkx/algorithms.py
+++ b/metagraph/plugins/networkx/algorithms.py
@@ -83,7 +83,11 @@ if has_networkx:
     @concrete_algorithm("subgraph.k_core")
     def nx_k_core(graph: NetworkXGraph, k: int) -> NetworkXGraph:
         k_core_graph = nx.k_core(graph.value, k)
-        return NetworkXGraph(k_core_graph, edge_weight_label=graph.edge_weight_label)
+        return NetworkXGraph(
+            k_core_graph,
+            node_weight_label=graph.node_weight_label,
+            edge_weight_label=graph.edge_weight_label,
+        )
 
     @concrete_algorithm("traversal.bellman_ford")
     def nx_bellman_ford(
@@ -115,6 +119,15 @@ if has_networkx:
         return (
             PythonNodeMap(single_parent_map,),
             PythonNodeMap(distance_map,),
+        )
+
+    @concrete_algorithm("traversal.minimum_spanning_tree")
+    def nx_minimum_spanning_tree(graph: NetworkXGraph) -> NetworkXGraph:
+        mst_graph = nx.minimum_spanning_tree(graph.value)
+        return NetworkXGraph(
+            mst_graph,
+            node_weight_label=graph.node_weight_label,
+            edge_weight_label=graph.edge_weight_label,
         )
 
     @concrete_algorithm("centrality.betweenness")

--- a/metagraph/plugins/scipy/algorithms.py
+++ b/metagraph/plugins/scipy/algorithms.py
@@ -98,7 +98,6 @@ if has_scipy:
     def ss_max_flow(
         graph: ScipyGraph, source_node: NodeID, target_node: NodeID,
     ) -> Tuple[float, ScipyGraph]:
-        print(f"graph.edges.value.toarray() {repr(graph.edges.value.toarray())}")
         max_flow_result = ss.csgraph.maximum_flow(
             graph.edges.value, source_node, target_node
         )

--- a/metagraph/plugins/scipy/algorithms.py
+++ b/metagraph/plugins/scipy/algorithms.py
@@ -94,6 +94,21 @@ if has_scipy:
         bfs_ordered_nodes = graph.edges.node_list[bfs_ordered_incides]
         return NumpyVector(bfs_ordered_nodes)
 
+    @concrete_algorithm("flow.max_flow")
+    def ss_max_flow(
+        graph: ScipyGraph, source_node: NodeID, target_node: NodeID,
+    ) -> Tuple[float, ScipyGraph]:
+        print(f"graph.edges.value.toarray() {repr(graph.edges.value.toarray())}")
+        max_flow_result = ss.csgraph.maximum_flow(
+            graph.edges.value, source_node, target_node
+        )
+        flow_value = max_flow_result.flow_value
+        residual_graph = max_flow_result.residual
+        residual_keep_mask = residual_graph > 0
+        ss_flow_graph = residual_graph.multiply(residual_keep_mask)
+        flow_graph = ScipyGraph(ss_flow_graph, nodes=graph.nodes)
+        return (flow_value, flow_graph)
+
     def _reduce_sparse_matrix(
         func: np.ufunc, sparse_matrix: ss.spmatrix
     ) -> Tuple[np.ndarray, np.ndarray]:

--- a/metagraph/plugins/scipy/algorithms.py
+++ b/metagraph/plugins/scipy/algorithms.py
@@ -46,6 +46,21 @@ if has_scipy:
             ScipyGraph(ScipyEdgeMap(lengths, graph.edges.node_list), nodes=graph.nodes),
         )
 
+    @concrete_algorithm("traversal.minimum_spanning_tree")
+    def ss_minimum_spanning_tree(graph: ScipyGraph) -> ScipyGraph:
+        span_tree = ss.csgraph.minimum_spanning_tree(graph.edges.value)
+        span_tree_mask = (span_tree != 0).astype(int, copy=False)
+        span_tree_mask_transposed = span_tree_mask.T
+        divisor = span_tree_mask + span_tree_mask_transposed
+        undirected_span_tree = span_tree + span_tree.T
+        # assert (undirected_span_tree.indices == divisor.indices).all()
+        # assert (undirected_span_tree.indptr == divisor.indptr).all()
+        undirected_span_tree.data /= divisor.data
+        undirected_span_tree = undirected_span_tree.astype(
+            graph.edges.value.dtype, copy=False
+        )
+        return ScipyGraph(undirected_span_tree, nodes=graph.nodes)
+
     @concrete_algorithm("cluster.triangle_count")
     def ss_triangle_count(graph: ScipyGraph) -> int:
         """

--- a/metagraph/tests/algorithms/__init__.py
+++ b/metagraph/tests/algorithms/__init__.py
@@ -48,6 +48,19 @@ class MultiVerify:
 
         self.plans = plans
 
+    def _translate_atomic_type(self, value, dst_type, algo_path):
+        try:
+            if dst_type in (float, int):
+                translated_value = value
+            else:
+                translated_value = self.resolver.translate(value, dst_type)
+        except TypeError:
+            raise UnsatisfiableAlgorithmError(
+                f"[{algo_path}] Unable to convert returned type {type(value)} "
+                f"into type {dst_type} for comparison"
+            )
+        return translated_value
+
     def custom_compare(self, cmp_func: Callable, expected_type=None):
         """
         Calls cmp_func sequentially, passing in each concrete algorithm's output.
@@ -67,35 +80,33 @@ class MultiVerify:
                     assert len(expected_type) == len(
                         ret_val
                     ), f"[{algo_path}] {ret_val} is not the same length as {expected_type}"
+                    rv = []
                     for expected_type_elem, ret_val_elem in zip(expected_type, ret_val):
-                        rv = []
-                        try:
-                            rv.append(
-                                self.resolver.translate(
-                                    ret_val_elem, expected_type_elem
-                                )
-                            )
-                        except TypeError:
-                            raise UnsatisfiableAlgorithmError(
-                                f"[{algo_path}] Unable to convert returned type {type(ret_val_elem)} "
-                                f"into type {expected_type_elem} for comparison"
-                            )
-                        ret_val = tuple(rv)
-                elif expected_type is not None:
-                    try:
-                        ret_val = self.resolver.translate(ret_val, expected_type)
-                    except TypeError:
-                        raise UnsatisfiableAlgorithmError(
-                            f"[{algo_path}] Unable to convert returned type {type(ret_val)} "
-                            f"into type {expected_type} for comparison"
+                        translated_ret_val_elem = self._translate_atomic_type(
+                            ret_val_elem, expected_type_elem, algo_path
                         )
-
+                        rv.append(translated_ret_val_elem)
+                    ret_val = tuple(rv)
+                elif expected_type is not None:
+                    ret_val = self._translate_atomic_type(
+                        ret_val, expected_type, algo_path
+                    )
                 try:
                     cmp_func(ret_val)
                 except Exception:
                     print("Performing custom compare against:")
-                    print(ret_val)
-                    print(ret_val.value)
+
+                    def _print_ret_val(item):
+                        if hasattr(item, "value"):
+                            print(item.value)
+                        else:
+                            print(item)
+
+                    if isinstance(ret_val, tuple):
+                        for ret_val_elem in ret_val:
+                            _print_ret_val(ret_val_elem)
+                    else:
+                        _print_ret_val(ret_val)
                     raise
             except Exception:
                 print(f"Failed for {algo_path}")
@@ -138,7 +149,9 @@ class MultiVerify:
         )
         if issubclass(expected_type, ConcreteType):
             try:
-                compare_val = self.resolver.translate(ret_val, type(expected_val))
+                compare_val = self._translate_atomic_type(
+                    ret_val, type(expected_val), algo_path
+                )
                 try:
                     if not expected_type.is_typeclass_of(compare_val):
                         raise TypeError(

--- a/metagraph/tests/algorithms/__init__.py
+++ b/metagraph/tests/algorithms/__init__.py
@@ -50,10 +50,13 @@ class MultiVerify:
 
     def _translate_atomic_type(self, value, dst_type, algo_path):
         try:
-            if dst_type in (float, int):
-                translated_value = value
-            else:
+            if (
+                issubclass(dst_type, ConcreteType)
+                or dst_type in self.resolver.class_to_concrete
+            ):
                 translated_value = self.resolver.translate(value, dst_type)
+            else:
+                translated_value = value
         except TypeError:
             raise UnsatisfiableAlgorithmError(
                 f"[{algo_path}] Unable to convert returned type {type(value)} "
@@ -87,7 +90,7 @@ class MultiVerify:
                         )
                         rv.append(translated_ret_val_elem)
                     ret_val = tuple(rv)
-                elif expected_type is not None:
+                else:
                     ret_val = self._translate_atomic_type(
                         ret_val, expected_type, algo_path
                     )

--- a/metagraph/tests/algorithms/__init__.py
+++ b/metagraph/tests/algorithms/__init__.py
@@ -90,7 +90,7 @@ class MultiVerify:
                         )
                         rv.append(translated_ret_val_elem)
                     ret_val = tuple(rv)
-                else:
+                elif expected_type is not None:
                     ret_val = self._translate_atomic_type(
                         ret_val, expected_type, algo_path
                     )
@@ -151,30 +151,24 @@ class MultiVerify:
             type(expected_val), type(expected_val)
         )
         if issubclass(expected_type, ConcreteType):
+            compare_val = self._translate_atomic_type(
+                ret_val, type(expected_val), algo_path
+            )
             try:
-                compare_val = self._translate_atomic_type(
-                    ret_val, type(expected_val), algo_path
-                )
-                try:
-                    if not expected_type.is_typeclass_of(compare_val):
-                        raise TypeError(
-                            f"compare value must be {expected_type}, not {type(compare_val)}"
-                        )
-                    self.resolver.assert_equal(
-                        compare_val, expected_val, rel_tol=rel_tol, abs_tol=abs_tol
+                if not expected_type.is_typeclass_of(compare_val):
+                    raise TypeError(
+                        f"compare value must be {expected_type}, not {type(compare_val)}"
                     )
-                except AssertionError:
-                    print(f"compare_val        {compare_val}")
-                    print(f"compare_val.value  {compare_val.value}")
-                    print(f"expected_val       {expected_val}")
-                    print(f"expected_val.value {expected_val.value}")
-                    # breakpoint()
-                    raise
-            except TypeError:
-                raise UnsatisfiableAlgorithmError(
-                    f"[{algo_path}] Unable to convert returned type {type(ret_val)} "
-                    f"into type {type(expected_val)} for comparison"
+                self.resolver.assert_equal(
+                    compare_val, expected_val, rel_tol=rel_tol, abs_tol=abs_tol
                 )
+            except AssertionError:
+                print(f"compare_val        {compare_val}")
+                print(f"compare_val.value  {compare_val.value}")
+                print(f"expected_val       {expected_val}")
+                print(f"expected_val.value {expected_val.value}")
+                # breakpoint()
+                raise
         else:
             # Normal Python type
             if expected_type is float:

--- a/metagraph/tests/algorithms/test_flow.py
+++ b/metagraph/tests/algorithms/test_flow.py
@@ -65,30 +65,39 @@ v /      v /      v v
         assert actual_flow_graph.value.nodes() == expected_graph.value.nodes()
 
         bottleneck_nodes = [4, 2]
+        get_edge_weight = lambda edge: edge[2]
         for node in bottleneck_nodes:
             actual_total_in_flow = sum(
-                flow
-                for _, _, flow in actual_flow_graph.value.in_edges(
-                    node, data=expected_graph.edge_weight_label
+                map(
+                    get_edge_weight,
+                    actual_flow_graph.value.in_edges(
+                        node, data=expected_graph.edge_weight_label
+                    ),
                 )
             )
             expected_total_in_flow = sum(
-                flow
-                for _, _, flow in expected_graph.value.in_edges(
-                    node, data=expected_graph.edge_weight_label
+                map(
+                    get_edge_weight,
+                    expected_graph.value.in_edges(
+                        node, data=expected_graph.edge_weight_label
+                    ),
                 )
             )
             assert actual_total_in_flow == expected_total_in_flow
             actual_total_out_flow = sum(
-                flow
-                for _, _, flow in actual_flow_graph.value.out_edges(
-                    node, data=expected_graph.edge_weight_label
+                map(
+                    get_edge_weight,
+                    actual_flow_graph.value.out_edges(
+                        node, data=expected_graph.edge_weight_label
+                    ),
                 )
             )
             expected_total_out_flow = sum(
-                flow
-                for _, _, flow in expected_graph.value.out_edges(
-                    node, data=expected_graph.edge_weight_label
+                map(
+                    get_edge_weight,
+                    expected_graph.value.out_edges(
+                        node, data=expected_graph.edge_weight_label
+                    ),
                 )
             )
             assert actual_total_out_flow == expected_total_out_flow

--- a/metagraph/tests/algorithms/test_flow.py
+++ b/metagraph/tests/algorithms/test_flow.py
@@ -1,0 +1,98 @@
+from metagraph.tests.util import default_plugin_resolver
+import networkx as nx
+from . import MultiVerify
+from typing import Tuple
+import math
+
+
+def test_max_flow(default_plugin_resolver):
+    """
+0 ---9-> 1        5 --1--> 6
+|      ^ |      ^ |      /
+|     /  |     /  |     /
+10   2   3    7   5   11
+|  _/    |  /     |   /
+v /      v /      v v
+3 --8--> 4 ---4-> 2 --6--> 7
+    """
+    dpr = default_plugin_resolver
+    source_node = 0
+    target_node = 7
+    ebunch = [
+        (0, 1, 9),
+        (0, 3, 10),
+        (1, 4, 3),
+        (2, 7, 6),
+        (3, 1, 2),
+        (3, 4, 8),
+        (4, 5, 7),
+        (4, 2, 4),
+        (5, 2, 5),
+        (5, 6, 1),
+        (6, 2, 11),
+    ]
+    nx_graph = nx.DiGraph()
+    nx_graph.add_weighted_edges_from(ebunch)
+    graph = dpr.wrappers.Graph.NetworkXGraph(nx_graph, edge_weight_label="weight")
+
+    ebunch_answer = [
+        (0, 1, 0),
+        (0, 3, 6),
+        (1, 4, 0),
+        (2, 7, 6),
+        (3, 1, 0),
+        (3, 4, 6),
+        (4, 2, 0),
+        (4, 5, 6),
+        (5, 2, 5),
+        (5, 6, 1),
+        (6, 2, 1),
+    ]
+    nx_graph_answer = nx.DiGraph()
+    nx_graph_answer.add_weighted_edges_from(ebunch_answer)
+    expected_flow_value = 6
+    expected_graph = dpr.wrappers.Graph.NetworkXGraph(nx_graph_answer)
+
+    def cmp_func(x):
+        actual_flow_value, actual_flow_graph = x
+
+        rel_tol = 1e-9
+        abs_tol = 0.0
+        assert math.isclose(
+            actual_flow_value, expected_flow_value, rel_tol=rel_tol, abs_tol=abs_tol
+        )
+
+        assert actual_flow_graph.value.nodes() == expected_graph.value.nodes()
+
+        bottleneck_nodes = [4, 2]
+        for node in bottleneck_nodes:
+            actual_total_in_flow = sum(
+                flow
+                for _, _, flow in actual_flow_graph.value.in_edges(
+                    node, data=expected_graph.edge_weight_label
+                )
+            )
+            expected_total_in_flow = sum(
+                flow
+                for _, _, flow in expected_graph.value.in_edges(
+                    node, data=expected_graph.edge_weight_label
+                )
+            )
+            assert actual_total_in_flow == expected_total_in_flow
+            actual_total_out_flow = sum(
+                flow
+                for _, _, flow in actual_flow_graph.value.out_edges(
+                    node, data=expected_graph.edge_weight_label
+                )
+            )
+            expected_total_out_flow = sum(
+                flow
+                for _, _, flow in expected_graph.value.out_edges(
+                    node, data=expected_graph.edge_weight_label
+                )
+            )
+            assert actual_total_out_flow == expected_total_out_flow
+
+    MultiVerify(dpr, "flow.max_flow", graph, source_node, target_node).custom_compare(
+        cmp_func, (float, dpr.wrappers.Graph.NetworkXGraph.Type)
+    )

--- a/metagraph/tests/algorithms/test_traversal.py
+++ b/metagraph/tests/algorithms/test_traversal.py
@@ -144,3 +144,48 @@ v        v /        v
         dpr.wrappers.NodeMap.PythonNodeMap(node_to_length_mapping),
     )
     MultiVerify(dpr, "traversal.dijkstra", graph, 0).assert_equals(expected_answer)
+
+
+def test_minimum_spanning_tree(default_plugin_resolver):
+    """
+0 ---2-- 1        5 --10-- 6
+|      / |      / |      /
+|     /  |     /  |     /
+1    7   3    9   5   11
+|   /    |  /     |  /
+|        | /        /
+3 --8--- 4 ---4-- 2 --6--- 7
+    """
+    dpr = default_plugin_resolver
+    ebunch = [
+        (0, 3, 1),
+        (1, 0, 2),
+        (1, 4, 3),
+        (2, 4, 4),
+        (2, 5, 5),
+        (2, 7, 6),
+        (3, 1, 7),
+        (3, 4, 8),
+        (4, 5, 9),
+        (5, 6, 10),
+        (6, 2, 11),
+    ]
+    nx_graph = nx.Graph()
+    nx_graph.add_weighted_edges_from(ebunch)
+    graph = dpr.wrappers.Graph.NetworkXGraph(nx_graph)
+
+    ebunch_answer = [
+        (0, 3, 1),
+        (0, 1, 2),
+        (1, 4, 3),
+        (4, 2, 4),
+        (2, 5, 5),
+        (2, 7, 6),
+        (5, 6, 10),
+    ]
+    nx_graph_answer = nx.Graph()
+    nx_graph_answer.add_weighted_edges_from(ebunch_answer)
+    expected_answer = dpr.wrappers.Graph.NetworkXGraph(nx_graph_answer)
+    MultiVerify(dpr, "traversal.minimum_spanning_tree", graph).assert_equals(
+        expected_answer
+    )

--- a/metagraph/tests/algorithms/test_traversal.py
+++ b/metagraph/tests/algorithms/test_traversal.py
@@ -152,8 +152,8 @@ def test_minimum_spanning_tree(default_plugin_resolver):
 |      / |      / |      /
 |     /  |     /  |     /
 1    7   3    9   5   11
-|   /    |  /     |  /
-|        | /        /
+|  _/    |  /     |  /
+| /      | /      | /
 3 --8--- 4 ---4-- 2 --6--- 7
     """
     dpr = default_plugin_resolver
@@ -179,6 +179,48 @@ def test_minimum_spanning_tree(default_plugin_resolver):
         (0, 1, 2),
         (1, 4, 3),
         (4, 2, 4),
+        (2, 5, 5),
+        (2, 7, 6),
+        (5, 6, 10),
+    ]
+    nx_graph_answer = nx.Graph()
+    nx_graph_answer.add_weighted_edges_from(ebunch_answer)
+    expected_answer = dpr.wrappers.Graph.NetworkXGraph(nx_graph_answer)
+    MultiVerify(dpr, "traversal.minimum_spanning_tree", graph).assert_equals(
+        expected_answer
+    )
+
+
+def test_minimum_spanning_tree_dicsconnected(default_plugin_resolver):
+    """
+0 ---2-- 1        5 --10-- 6
+|      / |        |      /
+|     /  |        |     /
+1    7   3        5   11
+|  _/    |        |  /
+| /      |        | /
+3 --8--- 4        2 --6--- 7
+    """
+    dpr = default_plugin_resolver
+    ebunch = [
+        (0, 3, 1),
+        (1, 0, 2),
+        (1, 4, 3),
+        (2, 5, 5),
+        (2, 7, 6),
+        (3, 1, 7),
+        (3, 4, 8),
+        (5, 6, 10),
+        (6, 2, 11),
+    ]
+    nx_graph = nx.Graph()
+    nx_graph.add_weighted_edges_from(ebunch)
+    graph = dpr.wrappers.Graph.NetworkXGraph(nx_graph)
+
+    ebunch_answer = [
+        (0, 3, 1),
+        (0, 1, 2),
+        (1, 4, 3),
         (2, 5, 5),
         (2, 7, 6),
         (5, 6, 10),


### PR DESCRIPTION
This PR includes the abstract algorithms for minimum spanning tree and max flow.

This PR includes concrete algorithms for minimum spanning tree and max flow in the NetworkX and Scipy plugins.

The name "minimum spanning tree" is somewhat of a misnomer since both the concrete algorithms are actually for minimum spanning forest (which returns different minimum trees for each connected component). There's a test verifying this behavior. 

This PR also changes MultiVerify. It abstracts out the translation functionality. This is intended to make the code easier to read since it'll reduce the number of nested try/except blocks.

NOTE: The Scipy plugin's implementation of max flow only works with integer weights. It raises a `ValueError` if the weights are not ints as noted [here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csgraph.maximum_flow.html).