### PR TITLE
Documentation: Update Use Case Tutorial 3 to use metargaph.NodeLabels

### DIFF
--- a/docs/getting_started/use_case_3_ecommerce_customer_interests.ipynb
+++ b/docs/getting_started/use_case_3_ecommerce_customer_interests.ipynb
@@ -164,7 +164,7 @@
     }
    ],
    "source": [
-    "RAW_DATA_CSV = './data/ecommerce/data.csv' # https://www.kaggle.com/carrie1/ecommerce-data\n",
+    "RAW_DATA_CSV = './data.csv' # https://www.kaggle.com/carrie1/ecommerce-data\n",
     "data_df = pd.read_csv(RAW_DATA_CSV, encoding=\"ISO-8859-1\")\n",
     "data_df.head()"
    ]
@@ -566,7 +566,9 @@
     "\n",
     "Let's now find the communities of customers with similar purchases / interests. \n",
     "\n",
-    "First, we'll need to create a bipartite graph of customers and products. "
+    "First, we'll need to create a bipartite graph of customers and products. \n",
+    "\n",
+    "Let's grab the default resolver."
    ]
   },
   {
@@ -575,11 +577,271 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "r = mg.resolver\n",
-    "nx_bipartite_graph = nx.from_pandas_edgelist(data_df, 'CustomerID', 'StockCode')\n",
+    "r = mg.resolver"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's take a look at the nodes of the bipartite graph we're going to create. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "customer_ids = data_df['CustomerID']\n",
-    "stock_codes = data_df['StockCode']\n",
-    "bipartite_graph = r.wrappers.BipartiteGraph.NetworkXBipartiteGraph(nx_bipartite_graph, [customer_ids, stock_codes])"
+    "stock_codes = data_df['StockCode']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    17850\n",
+       "1    17850\n",
+       "2    17850\n",
+       "3    17850\n",
+       "4    17850\n",
+       "Name: CustomerID, dtype: int64"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "customer_ids.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    85123A\n",
+       "1     71053\n",
+       "2    84406B\n",
+       "3    84029G\n",
+       "4    84029E\n",
+       "Name: StockCode, dtype: object"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stock_codes.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our customer ids are ints, but our stock codes are not ints. \n",
+    "\n",
+    "Ideally, our graph will have nodes of all the same type since some hardware backends might require this. This isn't strictly necessary here, but it's good practice to do this in order to avoid any potential problems any specific backend might have. \n",
+    "\n",
+    "We can make our graph nodes all have the same type by mapping our original customer ids and stock codes to node ids and making a graph of those node ids. We can do this with `metagrgaph.NodeLabels`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_nodes = pd.concat([customer_ids, stock_codes]).unique()\n",
+    "node_ids = range(len(all_nodes))\n",
+    "node_labels = mg.NodeLabels(node_ids, all_nodes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`node_labels` maps the customer ids or stock codes to node ids as shown below. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "17850"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "first_customer_id = customer_ids.iloc[0]\n",
+    "first_customer_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "first_customer_id_node_id = node_labels[first_customer_id]\n",
+    "first_customer_id_node_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'85123A'"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "first_stock_code = stock_codes.iloc[0]\n",
+    "first_stock_code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4339"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "first_stock_code_node_id = node_labels[first_stock_code]\n",
+    "first_stock_code_node_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`node_labels.ids` maps node ids to customer ids or stock codes as shown below. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "17850"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "node_labels.ids[first_customer_id_node_id]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'85123A'"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "node_labels.ids[first_stock_code_node_id]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert node_labels.ids[first_customer_id_node_id] == first_customer_id\n",
+    "assert node_labels.ids[first_stock_code_node_id] == first_stock_code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's now create our bipartite graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "customer_id_node_ids = [node_labels[customer_id] for customer_id in customer_ids]\n",
+    "stock_code_node_ids = [node_labels[stock_code] for stock_code in stock_codes]\n",
+    "edges = zip(customer_id_node_ids, stock_code_node_ids)\n",
+    "\n",
+    "nx_bipartite_graph = nx.Graph()\n",
+    "nx_bipartite_graph.add_edges_from(edges)\n",
+    "bipartite_graph = r.wrappers.BipartiteGraph.NetworkXBipartiteGraph(\n",
+    "    nx_bipartite_graph, \n",
+    "    [customer_id_node_ids, stock_code_node_ids]\n",
+    ")"
    ]
   },
   {
@@ -591,7 +853,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -607,11 +869,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
-    "customer_similarity_graph = r.algos.util.graph.assign_uniform_weight(customer_similarity_graph, 1.0)"
+    "customer_similarity_graph = r.algos.util.graph.assign_uniform_weight(\n",
+    "    customer_similarity_graph, \n",
+    "    1.0\n",
+    ")"
    ]
   },
   {
@@ -623,23 +888,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
-    "labels, modularity_score = r.algos.clustering.louvain_community(customer_similarity_graph)"
+    "community_labels, modularity_score = r.algos.clustering.louvain_community(\n",
+    "    customer_similarity_graph\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's see how many / what labels we have."
+    "`community_labels` is a mapping from node IDs to their community labels. \n",
+    "\n",
+    "Let's see how many / what community labels we have."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -648,18 +917,18 @@
        "metagraph.plugins.python.types.PythonNodeMap"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "type(labels)"
+    "type(community_labels)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -668,18 +937,18 @@
        "dict"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "type(labels.value)"
+    "type(community_labels.value)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -688,13 +957,13 @@
        "{0, 1, 2, 3}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "set(labels.value.values())"
+    "set(community_labels.value.values())"
    ]
   },
   {
@@ -706,7 +975,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -743,174 +1012,176 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>105952</th>\n",
-       "      <td>545301</td>\n",
-       "      <td>21251</td>\n",
-       "      <td>DINOSAUR HEIGHT CHART STICKER SET</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2011-03-01 12:26:00</td>\n",
-       "      <td>2.95</td>\n",
-       "      <td>12679</td>\n",
-       "      <td>France</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>30090</th>\n",
-       "      <td>538849</td>\n",
-       "      <td>21484</td>\n",
-       "      <td>CHICK GREY HOT WATER BOTTLE</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2010-12-14 13:31:00</td>\n",
-       "      <td>3.45</td>\n",
-       "      <td>14415</td>\n",
-       "      <td>United Kingdom</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>367490</th>\n",
-       "      <td>568895</td>\n",
-       "      <td>23321</td>\n",
-       "      <td>SMALL WHITE HEART OF WICKER</td>\n",
-       "      <td>3</td>\n",
-       "      <td>2011-09-29 13:11:00</td>\n",
-       "      <td>1.65</td>\n",
-       "      <td>15356</td>\n",
-       "      <td>United Kingdom</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>441827</th>\n",
-       "      <td>574655</td>\n",
-       "      <td>22605</td>\n",
-       "      <td>WOODEN CROQUET GARDEN SET</td>\n",
+       "      <th>323176</th>\n",
+       "      <td>565248</td>\n",
+       "      <td>23237</td>\n",
+       "      <td>SET OF 4 KNICK KNACK TINS LEAF</td>\n",
        "      <td>1</td>\n",
-       "      <td>2011-11-06 11:35:00</td>\n",
-       "      <td>14.95</td>\n",
-       "      <td>16466</td>\n",
-       "      <td>United Kingdom</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7153</th>\n",
-       "      <td>536993</td>\n",
-       "      <td>21936</td>\n",
-       "      <td>RED RETROSPOT PICNIC BAG</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2010-12-03 15:19:00</td>\n",
-       "      <td>2.95</td>\n",
-       "      <td>14396</td>\n",
-       "      <td>United Kingdom</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>424295</th>\n",
-       "      <td>573248</td>\n",
-       "      <td>23318</td>\n",
-       "      <td>BOX OF 6 MINI VINTAGE CRACKERS</td>\n",
-       "      <td>10</td>\n",
-       "      <td>2011-10-28 12:09:00</td>\n",
-       "      <td>2.49</td>\n",
-       "      <td>14498</td>\n",
-       "      <td>United Kingdom</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3137</th>\n",
-       "      <td>536602</td>\n",
-       "      <td>22411</td>\n",
-       "      <td>JUMBO SHOPPER VINTAGE RED PAISLEY</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2010-12-02 08:34:00</td>\n",
-       "      <td>1.65</td>\n",
-       "      <td>17850</td>\n",
-       "      <td>United Kingdom</td>\n",
-       "      <td>2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>30247</th>\n",
-       "      <td>538853</td>\n",
-       "      <td>21677</td>\n",
-       "      <td>HEARTS  STICKERS</td>\n",
-       "      <td>6</td>\n",
-       "      <td>2010-12-14 13:35:00</td>\n",
-       "      <td>0.85</td>\n",
-       "      <td>16805</td>\n",
-       "      <td>United Kingdom</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>354297</th>\n",
-       "      <td>567873</td>\n",
-       "      <td>23273</td>\n",
-       "      <td>HEART T-LIGHT HOLDER WILLIE WINKIE</td>\n",
-       "      <td>12</td>\n",
-       "      <td>2011-09-22 14:25:00</td>\n",
-       "      <td>1.65</td>\n",
-       "      <td>13055</td>\n",
+       "      <td>2011-09-02 10:34:00</td>\n",
+       "      <td>4.15</td>\n",
+       "      <td>15860</td>\n",
        "      <td>United Kingdom</td>\n",
        "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>352970</th>\n",
-       "      <td>567709</td>\n",
-       "      <td>21915</td>\n",
-       "      <td>RED  HARMONICA IN BOX</td>\n",
+       "      <th>25576</th>\n",
+       "      <td>538374</td>\n",
+       "      <td>15056N</td>\n",
+       "      <td>EDWARDIAN PARASOL NATURAL</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2010-12-12 11:17:00</td>\n",
+       "      <td>5.95</td>\n",
+       "      <td>14159</td>\n",
+       "      <td>United Kingdom</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>301534</th>\n",
+       "      <td>563333</td>\n",
+       "      <td>48194</td>\n",
+       "      <td>DOORMAT HEARTS</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2011-08-15 13:09:00</td>\n",
+       "      <td>7.95</td>\n",
+       "      <td>15996</td>\n",
+       "      <td>United Kingdom</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>98971</th>\n",
+       "      <td>544691</td>\n",
+       "      <td>22777</td>\n",
+       "      <td>GLASS CLOCHE LARGE</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2011-02-23 09:09:00</td>\n",
+       "      <td>8.50</td>\n",
+       "      <td>13804</td>\n",
+       "      <td>United Kingdom</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>878</th>\n",
+       "      <td>536477</td>\n",
+       "      <td>22633</td>\n",
+       "      <td>HAND WARMER UNION JACK</td>\n",
        "      <td>12</td>\n",
-       "      <td>2011-09-22 09:53:00</td>\n",
-       "      <td>1.25</td>\n",
-       "      <td>15239</td>\n",
+       "      <td>2010-12-01 12:27:00</td>\n",
+       "      <td>2.10</td>\n",
+       "      <td>16210</td>\n",
        "      <td>United Kingdom</td>\n",
        "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8515</th>\n",
+       "      <td>537137</td>\n",
+       "      <td>22728</td>\n",
+       "      <td>ALARM CLOCK BAKELIKE PINK</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2010-12-05 12:43:00</td>\n",
+       "      <td>3.75</td>\n",
+       "      <td>16327</td>\n",
+       "      <td>United Kingdom</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>371878</th>\n",
+       "      <td>569228</td>\n",
+       "      <td>22066</td>\n",
+       "      <td>LOVE HEART TRINKET POT</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2011-10-02 14:47:00</td>\n",
+       "      <td>0.39</td>\n",
+       "      <td>15547</td>\n",
+       "      <td>United Kingdom</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>181344</th>\n",
+       "      <td>552466</td>\n",
+       "      <td>22178</td>\n",
+       "      <td>VICTORIAN GLASS HANGING T-LIGHT</td>\n",
+       "      <td>24</td>\n",
+       "      <td>2011-05-09 15:21:00</td>\n",
+       "      <td>1.25</td>\n",
+       "      <td>13458</td>\n",
+       "      <td>United Kingdom</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>194184</th>\n",
+       "      <td>553553</td>\n",
+       "      <td>23230</td>\n",
+       "      <td>WRAP ALPHABET DESIGN</td>\n",
+       "      <td>25</td>\n",
+       "      <td>2011-05-17 16:32:00</td>\n",
+       "      <td>0.42</td>\n",
+       "      <td>16156</td>\n",
+       "      <td>United Kingdom</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>498263</th>\n",
+       "      <td>578516</td>\n",
+       "      <td>22187</td>\n",
+       "      <td>GREEN CHRISTMAS TREE CARD HOLDER</td>\n",
+       "      <td>30</td>\n",
+       "      <td>2011-11-24 13:53:00</td>\n",
+       "      <td>1.95</td>\n",
+       "      <td>14591</td>\n",
+       "      <td>United Kingdom</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "       InvoiceNo StockCode                         Description  Quantity  \\\n",
-       "105952    545301     21251   DINOSAUR HEIGHT CHART STICKER SET         6   \n",
-       "30090     538849     21484         CHICK GREY HOT WATER BOTTLE         2   \n",
-       "367490    568895     23321         SMALL WHITE HEART OF WICKER         3   \n",
-       "441827    574655     22605           WOODEN CROQUET GARDEN SET         1   \n",
-       "7153      536993     21936            RED RETROSPOT PICNIC BAG         1   \n",
-       "424295    573248     23318      BOX OF 6 MINI VINTAGE CRACKERS        10   \n",
-       "3137      536602     22411   JUMBO SHOPPER VINTAGE RED PAISLEY         6   \n",
-       "30247     538853     21677                    HEARTS  STICKERS         6   \n",
-       "354297    567873     23273  HEART T-LIGHT HOLDER WILLIE WINKIE        12   \n",
-       "352970    567709     21915              RED  HARMONICA IN BOX         12   \n",
+       "       InvoiceNo StockCode                       Description  Quantity  \\\n",
+       "323176    565248     23237    SET OF 4 KNICK KNACK TINS LEAF         1   \n",
+       "25576     538374    15056N         EDWARDIAN PARASOL NATURAL         1   \n",
+       "301534    563333     48194                    DOORMAT HEARTS         1   \n",
+       "98971     544691     22777                GLASS CLOCHE LARGE         2   \n",
+       "878       536477     22633            HAND WARMER UNION JACK        12   \n",
+       "8515      537137     22728         ALARM CLOCK BAKELIKE PINK         1   \n",
+       "371878    569228     22066            LOVE HEART TRINKET POT         2   \n",
+       "181344    552466     22178   VICTORIAN GLASS HANGING T-LIGHT        24   \n",
+       "194184    553553     23230              WRAP ALPHABET DESIGN        25   \n",
+       "498263    578516     22187  GREEN CHRISTMAS TREE CARD HOLDER        30   \n",
        "\n",
        "               InvoiceDate  UnitPrice  CustomerID         Country  \\\n",
-       "105952 2011-03-01 12:26:00       2.95       12679          France   \n",
-       "30090  2010-12-14 13:31:00       3.45       14415  United Kingdom   \n",
-       "367490 2011-09-29 13:11:00       1.65       15356  United Kingdom   \n",
-       "441827 2011-11-06 11:35:00      14.95       16466  United Kingdom   \n",
-       "7153   2010-12-03 15:19:00       2.95       14396  United Kingdom   \n",
-       "424295 2011-10-28 12:09:00       2.49       14498  United Kingdom   \n",
-       "3137   2010-12-02 08:34:00       1.65       17850  United Kingdom   \n",
-       "30247  2010-12-14 13:35:00       0.85       16805  United Kingdom   \n",
-       "354297 2011-09-22 14:25:00       1.65       13055  United Kingdom   \n",
-       "352970 2011-09-22 09:53:00       1.25       15239  United Kingdom   \n",
+       "323176 2011-09-02 10:34:00       4.15       15860  United Kingdom   \n",
+       "25576  2010-12-12 11:17:00       5.95       14159  United Kingdom   \n",
+       "301534 2011-08-15 13:09:00       7.95       15996  United Kingdom   \n",
+       "98971  2011-02-23 09:09:00       8.50       13804  United Kingdom   \n",
+       "878    2010-12-01 12:27:00       2.10       16210  United Kingdom   \n",
+       "8515   2010-12-05 12:43:00       3.75       16327  United Kingdom   \n",
+       "371878 2011-10-02 14:47:00       0.39       15547  United Kingdom   \n",
+       "181344 2011-05-09 15:21:00       1.25       13458  United Kingdom   \n",
+       "194184 2011-05-17 16:32:00       0.42       16156  United Kingdom   \n",
+       "498263 2011-11-24 13:53:00       1.95       14591  United Kingdom   \n",
        "\n",
        "        CustomerCommunityLabel  \n",
-       "105952                       3  \n",
-       "30090                        2  \n",
-       "367490                       3  \n",
-       "441827                       2  \n",
-       "7153                         2  \n",
-       "424295                       1  \n",
-       "3137                         2  \n",
-       "30247                        1  \n",
-       "354297                       0  \n",
-       "352970                       1  "
+       "323176                       0  \n",
+       "25576                        3  \n",
+       "301534                       0  \n",
+       "98971                        3  \n",
+       "878                          1  \n",
+       "8515                         0  \n",
+       "371878                       0  \n",
+       "181344                       0  \n",
+       "194184                       2  \n",
+       "498263                       2  "
       ]
      },
-     "execution_count": 13,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "data_df['CustomerCommunityLabel'] = data_df.CustomerID.map(lambda customer_id: labels.value[customer_id])\n",
+    "data_df['CustomerCommunityLabel'] = data_df.CustomerID.map(\n",
+    "    lambda customer_id: community_labels.value[node_labels[customer_id]]\n",
+    ")\n",
     "data_df.sample(10)"
    ]
   },
@@ -939,9 +1210,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.7"
-  },
-  "nbsphinx": {
-   "execute": "never"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The ecommerce tutorial has a bipartite graph whose nodes are customer ids (instances of `int`) and stock codes (instances of `str`).

Some backends require all nodes of a bipartite graph to all be instances of the same type.

It's best practice to use `metagraph.NodeLabels` to have the nodes of graphs be the same type.

This pull request makes the ecommerce tutorial use `metagraph.NodeLabels`.