### PR TITLE
NetworkX bugfix

### DIFF
--- a/docs/user_guide/algorithms.rst
+++ b/docs/user_guide/algorithms.rst
@@ -71,14 +71,18 @@ As with the abstract algorithm, the actual name of the Python function does not 
 There is no convention for what it should be named.
 
 Notice that the signature matches the abstract algorithm, but choosing a concrete type rather
-than the abstract type.
+than the abstract type. Concrete algorithms must contain a matching entry for every parameter
+in the abstract signature, but may contain additional parameters which are specialized to this
+implementation.
+
+Each additional parameter must contain a default value. When calling using the normal dispatch
+mechanism, these default values will be used. The only way for a user to indicate a value for
+the additional parameters is to make an :ref:`exact algorithm call<exact_algorithm_call>`.
 
 The body of the function can be as complex as needed. Often, when building a plugin for an
 existing library, the concrete algorithm body is quite short because it calls the underlying
 library's implementation. The only thing else to do is package the results in the correct
 concrete type and return.
-
-*Open issue:* How to add custom parameters that can be passed when calling exact algorithms?
 
 
 Using the Resolver in Concrete Algorithms

--- a/docs/user_guide/resolver.rst
+++ b/docs/user_guide/resolver.rst
@@ -97,6 +97,8 @@ CuGraph and another which takes Pandas EdgeLists.
 The choice of which path to take depends on the number of translations as well as the performance
 of the concrete algorithms. Metagraph will attempt to minimize the total time taken.
 
+.. _exact_algorithm_call:
+
 Exact Algorithm Call
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/metagraph/plugins/networkx/types.py
+++ b/metagraph/plugins/networkx/types.py
@@ -142,12 +142,12 @@ if has_networkx:
                         val1 = d1[obj1.edge_weight_label]
                         val2 = d2[obj2.edge_weight_label]
 
-                    if aprops1["edge_dtype"] == "float":
-                        assert math.isclose(
-                            val1, val2, rel_tol=rel_tol, abs_tol=abs_tol
-                        ), f"{(e1, e2)} {val1} not close to {val2}"
-                    else:
-                        assert val1 == val2, f"{(e1, e2)} {val1} != {val2}"
+                        if aprops1["edge_dtype"] == "float":
+                            assert math.isclose(
+                                val1, val2, rel_tol=rel_tol, abs_tol=abs_tol
+                            ), f"{(e1, e2)} {val1} not close to {val2}"
+                        else:
+                            assert val1 == val2, f"{(e1, e2)} {val1} != {val2}"
 
     class NetworkXBipartiteGraph(BipartiteGraphWrapper, abstract=BipartiteGraph):
         def __init__(
@@ -328,9 +328,9 @@ if has_networkx:
                         val1 = d1[obj1.edge_weight_label]
                         val2 = d2[obj2.edge_weight_label]
 
-                    if aprops1["edge_dtype"] == "float":
-                        assert math.isclose(
-                            val1, val2, rel_tol=rel_tol, abs_tol=abs_tol
-                        ), f"{(e1, e2)} {val1} not close to {val2}"
-                    else:
-                        assert val1 == val2, f"{(e1, e2)} {val1} != {val2}"
+                        if aprops1["edge_dtype"] == "float":
+                            assert math.isclose(
+                                val1, val2, rel_tol=rel_tol, abs_tol=abs_tol
+                            ), f"{(e1, e2)} {val1} not close to {val2}"
+                        else:
+                            assert val1 == val2, f"{(e1, e2)} {val1} != {val2}"

--- a/metagraph/tests/types/test_graph.py
+++ b/metagraph/tests/types/test_graph.py
@@ -45,7 +45,7 @@ def test_networkx():
     )
     g_diff1 = nx.DiGraph()
     g_diff1.add_weighted_edges_from(
-        [(0, 0, 1), (0, 1, 2), (1, 1, 0), (1, 2, 3), (2, 1, 333)]
+        [(0, 0, 1), (0, 1, 2), (1, 1, 0), (1, 2, 333), (2, 1, 3)]
     )
     with pytest.raises(AssertionError):
         NetworkXGraph.Type.assert_equal(


### PR DESCRIPTION
`assert_equal` had an indentation bug so it wasn't testing what we thought it was.

I also included a small update to the docs for exact algorithm call additional parameters, which I apparently forgot to add.