### PR TITLE
Add transductive node embedding type

### DIFF
--- a/docs/user_guide/algorithms.rst
+++ b/docs/user_guide/algorithms.rst
@@ -71,14 +71,18 @@ As with the abstract algorithm, the actual name of the Python function does not 
 There is no convention for what it should be named.
 
 Notice that the signature matches the abstract algorithm, but choosing a concrete type rather
-than the abstract type.
+than the abstract type. Concrete algorithms must contain a matching entry for every parameter
+in the abstract signature, but may contain additional parameters which are specialized to this
+implementation.
+
+Each additional parameter must contain a default value. When calling using the normal dispatch
+mechanism, these default values will be used. The only way for a user to indicate a value for
+the additional parameters is to make an :ref:`exact algorithm call<exact_algorithm_call>`.
 
 The body of the function can be as complex as needed. Often, when building a plugin for an
 existing library, the concrete algorithm body is quite short because it calls the underlying
 library's implementation. The only thing else to do is package the results in the correct
 concrete type and return.
-
-*Open issue:* How to add custom parameters that can be passed when calling exact algorithms?
 
 
 Using the Resolver in Concrete Algorithms

--- a/docs/user_guide/resolver.rst
+++ b/docs/user_guide/resolver.rst
@@ -97,6 +97,8 @@ CuGraph and another which takes Pandas EdgeLists.
 The choice of which path to take depends on the number of translations as well as the performance
 of the concrete algorithms. Metagraph will attempt to minimize the total time taken.
 
+.. _exact_algorithm_call:
+
 Exact Algorithm Call
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/metagraph/algorithms/__init__.py
+++ b/metagraph/algorithms/__init__.py
@@ -2,6 +2,7 @@ from . import (
     bipartite,
     centrality,
     clustering,
+    embedding,
     flow,
     subgraph,
     traversal,

--- a/metagraph/algorithms/embedding.py
+++ b/metagraph/algorithms/embedding.py
@@ -1,0 +1,14 @@
+from metagraph import abstract_algorithm
+from metagraph.types import Graph, NodeEmbedding
+
+
+@abstract_algorithm("embedding.train.node2vec")
+def node2vec_train(
+    graph: Graph,
+    p: float,
+    q: float,
+    walks_per_node: int,
+    walk_length: int,
+    embedding_size: int,
+) -> NodeEmbedding:
+    pass  # pragma: no cover

--- a/metagraph/algorithms/embedding.py
+++ b/metagraph/algorithms/embedding.py
@@ -10,5 +10,7 @@ def node2vec_train(
     walks_per_node: int,
     walk_length: int,
     embedding_size: int,
+    epochs: int,
+    learning_rate: float,
 ) -> NodeEmbedding:
     pass  # pragma: no cover

--- a/metagraph/algorithms/utility.py
+++ b/metagraph/algorithms/utility.py
@@ -1,7 +1,17 @@
 import metagraph as mg
 from metagraph import abstract_algorithm
-from metagraph.types import NodeSet, NodeMap, Vector, NodeID, EdgeSet, EdgeMap, Graph
-from typing import Any, Callable
+from metagraph.types import (
+    NodeSet,
+    NodeMap,
+    Vector,
+    Matrix,
+    NodeID,
+    EdgeSet,
+    EdgeMap,
+    Graph,
+    NodeEmbedding,
+)
+from typing import Any, Tuple, Callable
 
 
 @abstract_algorithm("util.nodeset.choose_random")
@@ -97,4 +107,9 @@ def graph_collapse_by_label(
     labels: NodeMap,
     aggregator: Callable[[Any, Any], Any],
 ) -> Graph:
+    pass  # pragma: no cover
+
+
+@abstract_algorithm("util.node_embedding.apply")
+def node_embedding_apply(embedding: NodeEmbedding, nodes: Vector) -> Matrix:
     pass  # pragma: no cover

--- a/metagraph/plugins/networkx/types.py
+++ b/metagraph/plugins/networkx/types.py
@@ -142,12 +142,12 @@ if has_networkx:
                         val1 = d1[obj1.edge_weight_label]
                         val2 = d2[obj2.edge_weight_label]
 
-                    if aprops1["edge_dtype"] == "float":
-                        assert math.isclose(
-                            val1, val2, rel_tol=rel_tol, abs_tol=abs_tol
-                        ), f"{(e1, e2)} {val1} not close to {val2}"
-                    else:
-                        assert val1 == val2, f"{(e1, e2)} {val1} != {val2}"
+                        if aprops1["edge_dtype"] == "float":
+                            assert math.isclose(
+                                val1, val2, rel_tol=rel_tol, abs_tol=abs_tol
+                            ), f"{(e1, e2)} {val1} not close to {val2}"
+                        else:
+                            assert val1 == val2, f"{(e1, e2)} {val1} != {val2}"
 
     class NetworkXBipartiteGraph(BipartiteGraphWrapper, abstract=BipartiteGraph):
         def __init__(
@@ -328,9 +328,9 @@ if has_networkx:
                         val1 = d1[obj1.edge_weight_label]
                         val2 = d2[obj2.edge_weight_label]
 
-                    if aprops1["edge_dtype"] == "float":
-                        assert math.isclose(
-                            val1, val2, rel_tol=rel_tol, abs_tol=abs_tol
-                        ), f"{(e1, e2)} {val1} not close to {val2}"
-                    else:
-                        assert val1 == val2, f"{(e1, e2)} {val1} != {val2}"
+                        if aprops1["edge_dtype"] == "float":
+                            assert math.isclose(
+                                val1, val2, rel_tol=rel_tol, abs_tol=abs_tol
+                            ), f"{(e1, e2)} {val1} not close to {val2}"
+                        else:
+                            assert val1 == val2, f"{(e1, e2)} {val1} != {val2}"

--- a/metagraph/plugins/numpy/algorithms.py
+++ b/metagraph/plugins/numpy/algorithms.py
@@ -1,7 +1,13 @@
 import numpy as np
 from functools import reduce
 from metagraph import concrete_algorithm, NodeID
-from .types import NumpyVector, NumpyNodeMap, NumpyNodeSet
+from .types import (
+    NumpyVector,
+    NumpyMatrix,
+    NumpyNodeMap,
+    NumpyNodeSet,
+    NumpyNodeEmbedding,
+)
 from typing import Any, Callable, Optional
 from .. import has_numba
 
@@ -119,3 +125,12 @@ def np_nodemap_reduce(x: NumpyNodeMap, func: Callable[[Any, Any], Any]) -> Any:
     if not isinstance(func, np.ufunc):
         func = np.frompyfunc(func, 2, 1)
     return func.reduce(present_values)
+
+
+@concrete_algorithm("util.node_embedding.apply")
+def np_embedding_apply(
+    embedding: NumpyNodeEmbedding, nodes: NumpyVector
+) -> NumpyMatrix:
+    indices = embedding.nodes[nodes.value]
+    matrix = embedding.matrix.np_matrix(copy=False)[indices]
+    return NumpyMatrix(matrix)

--- a/metagraph/plugins/numpy/algorithms.py
+++ b/metagraph/plugins/numpy/algorithms.py
@@ -132,5 +132,5 @@ def np_embedding_apply(
     embedding: NumpyNodeEmbedding, nodes: NumpyVector
 ) -> NumpyMatrix:
     indices = embedding.nodes[nodes.value]
-    matrix = embedding.matrix.np_matrix(copy=False)[indices]
+    matrix = embedding.matrix.value[indices]
     return NumpyMatrix(matrix)

--- a/metagraph/plugins/numpy/types.py
+++ b/metagraph/plugins/numpy/types.py
@@ -261,8 +261,8 @@ class NumpyNodeMap(NodeMapWrapper, abstract=NodeMap):
 
     def __getitem__(self, key):
         return (
-            self._get_multiple_items(key)
-            if isinstance(key, np.ndarray)
+            self._get_multiple_items(np.array(key))
+            if hasattr(key, "__len__")
             else self._get_single_item(key)
         )
 

--- a/metagraph/plugins/numpy/types.py
+++ b/metagraph/plugins/numpy/types.py
@@ -405,6 +405,12 @@ class NumpyMatrix(Wrapper, abstract=Matrix):
         mask = None if self.mask is None else self.mask.copy()
         return NumpyMatrix(self.value.copy(), mask=mask)
 
+    def __getitem__(self, key):
+        item = self.value[key]
+        if self.mask is not None:
+            item = item[self.mask[key]]
+        return item
+
     class TypeMixin:
         @classmethod
         def _compute_abstract_properties(

--- a/metagraph/plugins/numpy/types.py
+++ b/metagraph/plugins/numpy/types.py
@@ -395,10 +395,10 @@ class NumpyMatrix(Wrapper, abstract=Matrix):
 
     def as_dense(self, fill_value=0, copy=False):
         matrix = self.value
-        if self.mask is not None:
-            matrix[~self.mask] = fill_value
         if copy:
             matrix = matrix.copy()
+        if self.mask is not None:
+            matrix[~self.mask] = fill_value
         return matrix
 
     def copy(self):
@@ -487,5 +487,5 @@ class NumpyNodeEmbedding(NodeEmbeddingWrapper, abstract=NodeEmbedding):
             )
 
     def copy(self):
-        nodes = self.nodes if self.nodes is None else self.nodes.copy()
+        nodes = None if self.nodes is None else self.nodes.copy()
         return NumpyNodeEmbedding(self.matrix.as_dense(copy=True), nodes=nodes)

--- a/metagraph/plugins/numpy/types.py
+++ b/metagraph/plugins/numpy/types.py
@@ -245,11 +245,12 @@ class NumpyNodeMap(NodeMapWrapper, abstract=NodeMap):
 
     def _get_multiple_items(self, node_ids: np.ndarray):
         if self.mask is not None:
-            if (node_ids >= len(self.mask)).any() or not self.mask[node_ids].all():
-                out_of_bounds_ids = node_ids[node_ids >= len(self.mask)]
-                mask_missing_ids = np.flatnonzero(~self.mask[node_ids])
-                missing_nodes = list(out_of_bounds_ids) + list(mask_missing_ids)
-                raise ValueError(f"nodes {missing_nodes} are not in the NodeMap")
+            if (node_ids >= len(self.mask)).any():
+                out_of_bound_ids = list(node_ids[node_ids > len(self.mask)])
+                raise ValueError(f"{out_of_bound_ids} are out of bounds")
+            if not self.mask[node_ids].all():
+                mask_missing_ids = list(np.flatnonzero(~self.mask[node_ids]))
+                raise ValueError(f"nodes {mask_missing_ids} are not in the NodeMap")
         elif self.id2pos is not None:
             missing_ids = [
                 node_id for node_id in node_ids if node_id not in self.id2pos

--- a/metagraph/plugins/numpy/types.py
+++ b/metagraph/plugins/numpy/types.py
@@ -405,12 +405,6 @@ class NumpyMatrix(Wrapper, abstract=Matrix):
         mask = None if self.mask is None else self.mask.copy()
         return NumpyMatrix(self.value.copy(), mask=mask)
 
-    def __getitem__(self, key):
-        item = self.value[key]
-        if self.mask is not None:
-            item = item[self.mask[key]]
-        return item
-
     class TypeMixin:
         @classmethod
         def _compute_abstract_properties(

--- a/metagraph/plugins/numpy/types.py
+++ b/metagraph/plugins/numpy/types.py
@@ -257,7 +257,7 @@ class NumpyNodeMap(NodeMapWrapper, abstract=NodeMap):
             ]
             if missing_ids:
                 raise ValueError(f"nodes {missing_ids} are not in the NodeMap")
-            node_ids = [self.id2pos[node_id] for node_id in node_ids]
+            node_ids = np.vectorize(self.id2pos.__getitem__)(node_ids)
         return self.value[node_ids]
 
     def __getitem__(self, key):

--- a/metagraph/plugins/numpy/types.py
+++ b/metagraph/plugins/numpy/types.py
@@ -483,4 +483,4 @@ class NumpyNodeEmbedding(NodeEmbeddingWrapper, abstract=NodeEmbedding):
 
     def copy(self):
         nodes = self.nodes if self.nodes is None else self.nodes.copy()
-        return NumpyNodeEmbedding(self.edges.matrix(), nodes=nodes)
+        return NumpyNodeEmbedding(self.matrix.np_matrix(copy=True), nodes=nodes)

--- a/metagraph/plugins/numpy/types.py
+++ b/metagraph/plugins/numpy/types.py
@@ -392,7 +392,7 @@ class NumpyMatrix(Wrapper, abstract=Matrix):
     def shape(self):
         return self.value.shape
 
-    def np_matrix(self, copy=False):
+    def as_dense(self, copy=False):
         """copy=False doesn't guarantee no copy is made since accounting for the mask forces a copy"""
         if self.mask is None:
             matrix = self.value
@@ -483,4 +483,4 @@ class NumpyNodeEmbedding(NodeEmbeddingWrapper, abstract=NodeEmbedding):
 
     def copy(self):
         nodes = self.nodes if self.nodes is None else self.nodes.copy()
-        return NumpyNodeEmbedding(self.matrix.np_matrix(copy=True), nodes=nodes)
+        return NumpyNodeEmbedding(self.matrix.as_dense(copy=True), nodes=nodes)

--- a/metagraph/plugins/numpy/types.py
+++ b/metagraph/plugins/numpy/types.py
@@ -392,14 +392,12 @@ class NumpyMatrix(Wrapper, abstract=Matrix):
     def shape(self):
         return self.value.shape
 
-    def as_dense(self, copy=False):
-        """copy=False doesn't guarantee no copy is made since accounting for the mask forces a copy"""
-        if self.mask is None:
-            matrix = self.value
-            if copy:
-                matrix = matrix.copy()
-        else:
-            matrix = self.value * self.mask
+    def as_dense(self, fill_value=0, copy=False):
+        matrix = self.value
+        if self.mask is not None:
+            matrix[~self.mask] = fill_value
+        if copy:
+            matrix = matrix.copy()
         return matrix
 
     def copy(self):

--- a/metagraph/tests/algorithms/test_embedding.py
+++ b/metagraph/tests/algorithms/test_embedding.py
@@ -51,8 +51,8 @@ def test_node2vec(default_plugin_resolver):
 
         for a_index in a_indices:
             for b_index in b_indices:
-                a_vector = embedding.matrix[a_index]
-                b_vector = embedding.matrix[b_index]
+                a_vector = np_matrix[a_index]
+                b_vector = np_matrix[b_index]
 
                 a_to_a_center = euclidean_dist(a_vector, a_centroid)
                 b_to_b_center = euclidean_dist(b_vector, b_centroid)

--- a/metagraph/tests/algorithms/test_embedding.py
+++ b/metagraph/tests/algorithms/test_embedding.py
@@ -1,0 +1,66 @@
+from metagraph.tests.util import default_plugin_resolver
+import networkx as nx
+import numpy as np
+
+from . import MultiVerify
+
+
+def test_node2vec(default_plugin_resolver):
+    dpr = default_plugin_resolver
+
+    # make uneven barbell graph
+    a_nodes = np.arange(10)
+    b_nodes = np.arange(80, 100)
+    complete_graph_a = nx.complete_graph(a_nodes)
+    complete_graph_b = nx.complete_graph(b_nodes)
+    nx_graph = nx.compose(complete_graph_a, complete_graph_b)
+    for node in range(9, 50):
+        nx_graph.add_edge(node, node + 1)
+    nx_graph.add_edge(50, 80)  # have non-consecutive node ids
+    graph = dpr.wrappers.Graph.NetworkXGraph(nx_graph)
+
+    mv = MultiVerify(dpr)
+
+    p = 1.0
+    q = 0.5
+    walks_per_node = 8
+    walk_length = 8
+    embedding_size = 25
+    epochs = 10_000
+    learning_rate = 1e-3
+    embedding = mv.compute(
+        "embedding.train.node2vec",
+        graph,
+        p,
+        q,
+        walks_per_node,
+        walk_length,
+        embedding_size,
+        epochs=epochs,
+        learning_rate=learning_rate,
+    )
+
+    euclidean_dist = lambda a, b: np.linalg.norm(a - b)
+
+    def cmp_func(embedding):
+        a_indices = list(range(10))
+        b_indices = list(range(51, 71))
+        np_matrix = embedding.matrix.as_dense(copy=False)
+        a_centroid = np_matrix[a_indices].mean(0)
+        b_centroid = np_matrix[b_indices].mean(0)
+
+        for a_index in a_indices:
+            for b_index in b_indices:
+                a_vector = embedding.matrix[a_index]
+                b_vector = embedding.matrix[b_index]
+
+                a_to_a_center = euclidean_dist(a_vector, a_centroid)
+                b_to_b_center = euclidean_dist(b_vector, b_centroid)
+                a_to_b = euclidean_dist(a_vector, b_vector)
+
+                assert a_to_a_center < a_to_b
+                assert a_to_a_center < a_to_b
+
+    embedding.normalize(dpr.types.NodeEmbedding.NumpyNodeEmbeddingType).custom_compare(
+        cmp_func
+    )

--- a/metagraph/tests/algorithms/test_utility.py
+++ b/metagraph/tests/algorithms/test_utility.py
@@ -464,3 +464,34 @@ def test_edgemap_from_edgeset(default_plugin_resolver):
     MultiVerify(dpr).compute("util.edgemap.from_edgeset", edgeset, 9).assert_equal(
         expected_answer
     )
+
+
+def test_node_embedding_apply(default_plugin_resolver):
+    dpr = default_plugin_resolver
+    matrix = np.arange(6).reshape(2, 3)
+    matrix = dpr.wrappers.Matrix.NumpyMatrix(matrix)
+    nodes = dpr.wrappers.NodeMap.NumpyNodeMap(
+        np.array([0, 1]), node_ids=np.array([9990, 9991])
+    )
+    embedding = dpr.wrappers.NodeEmbedding.NumpyNodeEmbedding(matrix, nodes)
+
+    MultiVerify(dpr).compute(
+        "util.node_embedding.apply",
+        embedding,
+        dpr.wrappers.Vector.NumpyVector(np.array([9990])),
+    ).assert_equal(dpr.wrappers.Matrix.NumpyMatrix(np.array([[0, 1, 2]])))
+    MultiVerify(dpr).compute(
+        "util.node_embedding.apply",
+        embedding,
+        dpr.wrappers.Vector.NumpyVector(np.array([9991])),
+    ).assert_equal(dpr.wrappers.Matrix.NumpyMatrix(np.array([[3, 4, 5]])))
+    MultiVerify(dpr).compute(
+        "util.node_embedding.apply",
+        embedding,
+        dpr.wrappers.Vector.NumpyVector(np.array([9990, 9991])),
+    ).assert_equal(matrix)
+    MultiVerify(dpr).compute(
+        "util.node_embedding.apply",
+        embedding,
+        dpr.wrappers.Vector.NumpyVector(np.array([9991, 9990])),
+    ).assert_equal(dpr.wrappers.Matrix.NumpyMatrix(np.array([[3, 4, 5], [0, 1, 2]])))

--- a/metagraph/tests/translators/test_node_map.py
+++ b/metagraph/tests/translators/test_node_map.py
@@ -11,7 +11,7 @@ import numpy as np
 import grblas
 
 
-def test_python_2_numpy(default_plugin_resolver):
+def test_python_2_numpy_node_ids(default_plugin_resolver):
     dpr = default_plugin_resolver
     x = PythonNodeMap({0: 12.5, 1: 33.4, 42: -1.2})
     assert x.num_nodes == 3
@@ -23,6 +23,27 @@ def test_python_2_numpy(default_plugin_resolver):
     dpr.assert_equal(y, intermediate)
     # Convert python <- numpy
     x2 = dpr.translate(y, PythonNodeMap)
+    dpr.assert_equal(x, x2)
+
+
+def test_numpy_mask_2_python(default_plugin_resolver):
+    dpr = default_plugin_resolver
+    x = NumpyNodeMap(
+        np.array([100, 101, 99999, 103]), mask=np.array([1, 1, 0, 1], dtype=bool)
+    )
+    assert x[0] == 100
+    assert x[1] == 101
+    with pytest.raises(ValueError, match="is not in the NodeMap"):
+        x[2]
+    assert x[3] == 103
+    assert (x[np.array([0, 1, 3])] == [100, 101, 103]).all()
+    assert x.num_nodes == 3
+    # Convert numpy -> python
+    intermediate = PythonNodeMap({0: 100, 1: 101, 3: 103})
+    y = dpr.translate(x, PythonNodeMap)
+    dpr.assert_equal(y, intermediate)
+    # Convert numpy <- python
+    x2 = dpr.translate(y, NumpyNodeMap)
     dpr.assert_equal(x, x2)
 
 

--- a/metagraph/tests/types/test_graph.py
+++ b/metagraph/tests/types/test_graph.py
@@ -45,7 +45,7 @@ def test_networkx():
     )
     g_diff1 = nx.DiGraph()
     g_diff1.add_weighted_edges_from(
-        [(0, 0, 1), (0, 1, 2), (1, 1, 0), (1, 2, 3), (2, 1, 333)]
+        [(0, 0, 1), (0, 1, 2), (1, 1, 0), (1, 2, 333), (2, 1, 3)]
     )
     with pytest.raises(AssertionError):
         NetworkXGraph.Type.assert_equal(

--- a/metagraph/types.py
+++ b/metagraph/types.py
@@ -33,10 +33,6 @@ class Matrix(AbstractType):
         "dtype": DTYPE_CHOICES,
     }
 
-    @Wrapper.required_method
-    def __getitem__(self, key):
-        raise NotImplementedError()
-
 
 class DataFrame(AbstractType):
     pass

--- a/metagraph/types.py
+++ b/metagraph/types.py
@@ -125,4 +125,11 @@ class BipartiteGraph(AbstractType):
     unambiguous_subcomponents = {EdgeSet}
 
 
+#################################
+# Embedding
+#################################
+class NodeEmbedding(AbstractType):
+    pass
+
+
 del AbstractType, Wrapper

--- a/metagraph/types.py
+++ b/metagraph/types.py
@@ -129,7 +129,9 @@ class BipartiteGraph(AbstractType):
 # Embedding
 #################################
 class NodeEmbedding(AbstractType):
-    pass
+    properties = {
+        "matrix_dtype": DTYPE_CHOICES,
+    }
 
 
 del AbstractType, Wrapper

--- a/metagraph/types.py
+++ b/metagraph/types.py
@@ -33,6 +33,10 @@ class Matrix(AbstractType):
         "dtype": DTYPE_CHOICES,
     }
 
+    @Wrapper.required_method
+    def __getitem__(self, key):
+        raise NotImplementedError()
+
 
 class DataFrame(AbstractType):
     pass

--- a/metagraph/wrappers.py
+++ b/metagraph/wrappers.py
@@ -206,8 +206,8 @@ class NodeEmbeddingWrapper(Wrapper, abstract=NodeEmbedding, register=False):
             matrix_class.assert_equal(
                 obj1.matrix,
                 obj2.matrix,
-                {"dtype": aprops1["dtype"]},
-                {"dtype": aprops2["dtype"]},
+                {"dtype": aprops1["matrix_dtype"]},
+                {"dtype": aprops2["matrix_dtype"]},
                 {},
                 {},
                 rel_tol=rel_tol,
@@ -218,8 +218,8 @@ class NodeEmbeddingWrapper(Wrapper, abstract=NodeEmbedding, register=False):
             nodes_class.assert_equal(
                 obj1.nodes,
                 obj2.nodes,
-                {"dtype": aprops1["dtype"]},
-                {"dtype": aprops2["dtype"]},
+                {},
+                {},
                 {},
                 {},
                 rel_tol=rel_tol,


### PR DESCRIPTION
This PR adds the following abstract algorithms:
* `embedding.train.node2vec`
* `util.node_embedding.apply`

This PR adds the abstract type `NodeEmbedding` and the wrapper `NodeEmbeddingWrapper`.

The motivation for this is:
* A transductive embedding can only embed things seen during training.
* An inductive can embed things unseen during training.
* Looking at the embedding algorithms we currently intend to implement (`graph2vec`, `node2vec`, `HOPE`,  `LINE`, `graph_sage`, `graph_wave`), there are 3 types of embedding abstract types we need. They are the transductive node embedding type, transductive graph embedding type, and inductive node embedding type. Our current list of embedding algorithms don't motivate the need for an inductive graph embedding type.
* Applying a transductive node embedding to a node will require only a node (since the graph is fixed and was seen during training) and will return a vector.
* Applying a transductive graph embedding to a graph will require only a graph (that was seen during training) and will return a vector.
* Applying an inductive node embedding will require a graph and a node (neither of which were necessarily seen during training) and will return a vector corresponding to the node.
* The `node2vec`, `HOPE`, `LINE`, and `graph_wave` algorithms produce a transductive node embedding.
* The `graph2vec` algorithm produces a transductive graph embedding.
* The `graph_sage` algorithm produces an inductive node embedding.

`NodeEmbedding` is the abstract type for transductive node embeddings. The nice thing about transductive node embeddings is that we know exactly what nodes can be embdedded. Thus, when a `NodeEmbedding` is instantiated, it can easily be represented as a matrix + mapping (`NodeEmbeddingWrapper` is implemented this way). This will make translations straightforward. This is not neccessarily true for inductive node embeddings. 

`embedding.train.node2vec` is the abstract algorithm to perform the training phase of the `node2vec` algorithm to produce a transductive node embedding (in the form of a concrete type instance corresponding to `NodeEmbedding`).

`util.node_embedding.apply` will take a transductive node embedding and vector of node ids and will return a matrix of the embedding vectors (each row corresponds to the embedding vector of the given node ids; the order of the rows match the order of the input vector of node ids).

Perhaps we'll want to change the naming convention to call it "util.transductive_node_embedding.apply" to differentiate it from the not-yet-implemented inductive node embedding abstract algorithm. We'll revisit this when we implement the inductive node embedding abstract algorithm.

This PR contains a test for `util.node_embedding.apply` (see `test_node_embedding_apply`).

This PR adds the concrete type `NumpyNodeEmbedding`.

This PR also adds array accessing for `NumpyNodeMap`, e.g.
```
    nm = NumpyNodeMap(np.array([100, 101, 99999, 103]), mask=np.array([1, 1, 0, 1],  dtype=bool))
    selector = np.array([0,3])
    nm[selector] # this is now valid
```
This only works for `np.ndarray` instances (but not Python lists as is supported in numpy; we could easily add this if desired).

There's a test for this in `test_python_2_numpy_mask`.

This PR also adds the method np_matrix for `NumpyNodeMap`. It simply returns the `numpy` matrix (accounting for the mask if necessary).