### PR TITLE
Test & Abstract Algorithm for embedding.train.graphwave

### DIFF
--- a/metagraph/algorithms/embedding.py
+++ b/metagraph/algorithms/embedding.py
@@ -1,5 +1,5 @@
 from metagraph import abstract_algorithm
-from metagraph.types import Graph, NodeEmbedding
+from metagraph.types import Graph, Vector, NodeEmbedding, GraphSageNodeEmbedding
 
 
 @abstract_algorithm("embedding.train.node2vec")
@@ -13,4 +13,38 @@ def node2vec_train(
     epochs: int,
     learning_rate: float,
 ) -> NodeEmbedding:
+    pass  # pragma: no cover
+
+
+@abstract_algorithm("embedding.train.graphwave")
+def graphwave_train(
+    graph: Graph(edge_type="set", is_directed=False),
+    scales: Vector,
+    sample_point_count: int,
+    sample_point_max: float,
+    chebyshev_degree: int,
+) -> NodeEmbedding:
+    pass  # pragma: no cover
+
+@abstract_algorithm("embedding.train.hope.katz")
+def hope_katz_train(
+        graph: Graph(edge_type="map", is_directed=True),
+        embedding_size: int,
+        beta: float
+) -> NodeEmbedding:
+    # embedding_size is ideally even since HOPE learns 2 embedding vectors of size embedding_size // 2 and concatenates them
+    pass  # pragma: no cover
+
+@abstract_algorithm("embedding.train.graph_sage.mean")
+def graph_sage_mean_train(
+        graph: Graph(edge_type="map", is_directed=True),
+        node_features: NodeEmbedding,
+        walk_length: int,
+        walks_per_node: int,
+        layer_sizes: Vector,
+        samples_per_layer: Vector,
+        epochs: int,
+        learning_rate: float,
+        batch_size: int,
+) -> GraphSageNodeEmbedding:
     pass  # pragma: no cover

--- a/metagraph/algorithms/utility.py
+++ b/metagraph/algorithms/utility.py
@@ -10,6 +10,7 @@ from metagraph.types import (
     EdgeMap,
     Graph,
     NodeEmbedding,
+    GraphSageNodeEmbedding,
 )
 from typing import Any, Tuple, Callable
 
@@ -124,4 +125,9 @@ def graph_isomorphic(g1: Graph, g2: Graph) -> bool:
 
 @abstract_algorithm("util.node_embedding.apply")
 def node_embedding_apply(embedding: NodeEmbedding, nodes: Vector) -> Matrix:
+    pass  # pragma: no cover
+
+
+@abstract_algorithm("util.inductive_node_embedding.apply")
+def inductive_node_embedding_apply(embedding: GraphSageNodeEmbedding, graph: Graph, node_features: NodeEmbedding) -> Matrix:
     pass  # pragma: no cover

--- a/metagraph/algorithms/utility.py
+++ b/metagraph/algorithms/utility.py
@@ -128,6 +128,8 @@ def node_embedding_apply(embedding: NodeEmbedding, nodes: Vector) -> Matrix:
     pass  # pragma: no cover
 
 
-@abstract_algorithm("util.inductive_node_embedding.apply")
-def inductive_node_embedding_apply(embedding: GraphSageNodeEmbedding, graph: Graph, node_features: NodeEmbedding) -> Matrix:
+@abstract_algorithm("util.graph_sage_node_embedding.apply")
+def graph_sage_node_embedding_apply(
+    embedding: GraphSageNodeEmbedding, graph: Graph, node_features: NodeEmbedding
+) -> Matrix:
     pass  # pragma: no cover

--- a/metagraph/plugins/numpy/types.py
+++ b/metagraph/plugins/numpy/types.py
@@ -126,7 +126,7 @@ class NumpyVector(Wrapper, abstract=Vector):
 
     def as_dense(self, fill_value=0, copy=False) -> np.ndarray:
         vector = self.value
-        if copy:
+        if copy or self.mask is not None:
             vector = vector.copy()
         if self.mask is not None:
             vector[~self.mask] = fill_value
@@ -407,7 +407,7 @@ class NumpyMatrix(Wrapper, abstract=Matrix):
 
     def as_dense(self, fill_value=0, copy=False) -> np.ndarray:
         matrix = self.value
-        if copy:
+        if copy or self.mask is not None:
             matrix = matrix.copy()
         if self.mask is not None:
             matrix[~self.mask] = fill_value

--- a/metagraph/plugins/numpy/types.py
+++ b/metagraph/plugins/numpy/types.py
@@ -120,6 +120,18 @@ class NumpyVector(Wrapper, abstract=Vector):
             if mask.shape != data.shape:
                 raise ValueError("mask must be the same shape as data")
 
+    @property
+    def shape(self):
+        return self.value.shape
+
+    def as_dense(self, fill_value=0, copy=False) -> np.ndarray:
+        vector = self.value
+        if copy:
+            vector = vector.copy()
+        if self.mask is not None:
+            vector[~self.mask] = fill_value
+        return vector
+
     def __len__(self):
         return len(self.value)
 
@@ -393,7 +405,7 @@ class NumpyMatrix(Wrapper, abstract=Matrix):
     def shape(self):
         return self.value.shape
 
-    def as_dense(self, fill_value=0, copy=False):
+    def as_dense(self, fill_value=0, copy=False) -> np.ndarray:
         matrix = self.value
         if copy:
             matrix = matrix.copy()
@@ -482,4 +494,5 @@ class NumpyNodeEmbedding(NodeEmbeddingWrapper, abstract=NodeEmbedding):
 
     def copy(self):
         nodes = None if self.nodes is None else self.nodes.copy()
-        return NumpyNodeEmbedding(self.matrix.as_dense(copy=True), nodes=nodes)
+        matrix = NumpyMatrix(self.matrix.as_dense(copy=True))
+        return NumpyNodeEmbedding(matrix, nodes=nodes)

--- a/metagraph/tests/algorithms/test_embedding.py
+++ b/metagraph/tests/algorithms/test_embedding.py
@@ -1,9 +1,11 @@
 from metagraph.tests.util import default_plugin_resolver
 import networkx as nx
 import numpy as np
+import math
 
 from . import MultiVerify
 
+euclidean_dist = lambda a, b: np.linalg.norm(a - b)
 
 def test_node2vec(default_plugin_resolver):
     dpr = default_plugin_resolver
@@ -33,10 +35,9 @@ def test_node2vec(default_plugin_resolver):
         walks_per_node,
         walk_length,
         embedding_size,
-        epochs=epochs,
-        learning_rate=learning_rate,
+        epochs,
+        learning_rate,
     )
-    euclidean_dist = lambda a, b: np.linalg.norm(a - b)
 
     def cmp_func(embedding):
         a_indices = list(range(10))
@@ -52,9 +53,132 @@ def test_node2vec(default_plugin_resolver):
                 b_to_b_center = euclidean_dist(b_vector, b_centroid)
                 a_to_b = euclidean_dist(a_vector, b_vector)
 
+                # TODO consider using a hard-coded constant here for a more robust test
                 assert a_to_a_center < a_to_b
                 assert b_to_b_center < a_to_b
 
     embedding.normalize(dpr.types.NodeEmbedding.NumpyNodeEmbeddingType).custom_compare(
         cmp_func
     )
+
+
+def test_graphwave(default_plugin_resolver):
+    dpr = default_plugin_resolver
+
+    # make uneven barbell graph
+    complete_graph_size = 10
+    path_length = 11
+    nx_graph = nx.barbell_graph(m1=complete_graph_size, m2=path_length)
+
+    a_start_node = 0
+    path_start_node = complete_graph_size
+    b_start_node = path_length + complete_graph_size
+
+    a_nodes = np.arange(a_start_node, path_start_node)
+    path_nodes = np.arange(path_start_node, b_start_node)
+    b_nodes = np.arange(b_start_node, len(nx_graph.nodes))
+
+    node_to_class = np.empty(len(nx_graph.nodes))
+    node_to_class[a_nodes] = 0
+    node_to_class[b_nodes] = 0
+    path_middle_node = path_start_node + math.ceil((b_start_node - path_start_node) / 2)
+    for i, path_node_id in enumerate(range(path_start_node, path_middle_node), start=1):
+        class_label = i
+        node_to_class[path_node_id] = class_label
+        node_to_class[b_start_node - i] = class_label
+    classes = np.unique(node_to_class)
+
+    graph = dpr.wrappers.Graph.NetworkXGraph(nx_graph)
+
+    mv = MultiVerify(dpr)
+
+    scales = dpr.wrappers.Vector.NumpyVector(np.array([5, 10]))
+    sample_point_count = 50
+    sample_point_max = 100.0
+    chebyshev_degree = 20
+    embedding = mv.compute(
+        "embedding.train.graphwave",
+        graph,
+        scales,
+        sample_point_count,
+        sample_point_max,
+        chebyshev_degree,
+    )
+
+    def cmp_func(embedding):
+        np_matrix = embedding.matrix.as_dense(copy=False)
+
+        class_to_vectors = {c: [] for c in classes}
+        for node_id in range(len(nx_graph.nodes)):
+            c = node_to_class[node_id]
+            class_to_vectors[c].append(np_matrix[node_id])
+
+        class_to_mean_vector = {
+            c: np.stack(vectors).mean(axis=0) for c, vectors in class_to_vectors.items()
+        }
+
+        class_to_max_dist_from_mean = {
+            c: max(
+                map(
+                    lambda vector: euclidean_dist(vector, class_to_mean_vector[c]),
+                    vectors,
+                )
+            )
+            for c, vectors in class_to_vectors.items()
+        }
+
+        for c, max_dist in class_to_max_dist_from_mean.items():
+            assert max_dist < 0.325
+
+    embedding.normalize(dpr.types.NodeEmbedding.NumpyNodeEmbeddingType).custom_compare(
+        cmp_func
+    )
+
+# def test_hope_katz(default_plugin_resolver):
+#     dpr = default_plugin_resolver
+
+#     # make two unidirectional circle graphs connected by one node
+#     a_nodes = np.arange(10)
+#     b_nodes = np.arange(10, 20)
+
+#     nx_graph = nx.DiGraph()
+
+#     for i in range(9):
+#         a_src_node = a_nodes[i]
+#         a_dst_node = a_nodes[i+1]
+#         b_src_node = b_nodes[i]
+#         b_dst_node = b_nodes[i+1]
+#         nx_graph.add_edge(a_src_node, a_dst_node, weight = 25)
+#         nx_graph.add_edge(b_src_node, b_dst_node, weight = 25)
+
+#     nx_graph.add_edge(0, 1_000, weight = 1)
+#     nx_graph.add_edge(10, 1_000, weight = 1)
+    
+#     graph = dpr.wrappers.Graph.NetworkXGraph(nx_graph)
+
+#     mv = MultiVerify(dpr)
+
+#     embedding_size = 10
+#     embedding = mv.compute(
+#         "embedding.train.hope.katz",
+#         graph,
+#         embedding_size,
+#     )
+
+#     def cmp_func(embedding):
+#         np_matrix = embedding.matrix.as_dense(copy=False)
+        
+#         mean_a_vector = np.stack(np_matrix[embedding.nodes[a_node]] for a_node in a_nodes).mean(axis=0)
+#         mean_b_vector = np.stack(np_matrix[embedding.nodes[b_node]] for b_node in b_nodes).mean(axis=0)
+
+#         max_dist_from_mean_a = max(euclidean_dist(mean_a_vector, np_matrix[embedding.nodes[a_node]]) for a_node in a_nodes)
+#         max_dist_from_mean_b = max(euclidean_dist(mean_b_vector, np_matrix[embedding.nodes[b_node]]) for b_node in b_nodes)
+
+#         print(f"max_dist_from_mean_a {repr(max_dist_from_mean_a)}")
+#         print(f"max_dist_from_mean_b {repr(max_dist_from_mean_b)}")
+        
+#         assert False
+
+#     embedding.normalize(dpr.types.NodeEmbedding.NumpyNodeEmbeddingType).custom_compare(
+#         cmp_func
+#     )

--- a/metagraph/tests/algorithms/test_embedding.py
+++ b/metagraph/tests/algorithms/test_embedding.py
@@ -65,7 +65,6 @@ def test_node2vec(default_plugin_resolver):
 def test_graphwave(default_plugin_resolver):
     dpr = default_plugin_resolver
 
-    # make uneven barbell graph
     complete_graph_size = 10
     path_length = 11
     nx_graph = nx.barbell_graph(m1=complete_graph_size, m2=path_length)

--- a/metagraph/types.py
+++ b/metagraph/types.py
@@ -133,7 +133,9 @@ class NodeEmbedding(AbstractType):
         "matrix_dtype": DTYPE_CHOICES,
     }
 
+
 class GraphSageNodeEmbedding(AbstractType):
     pass
+
 
 del AbstractType, Wrapper

--- a/metagraph/types.py
+++ b/metagraph/types.py
@@ -133,5 +133,7 @@ class NodeEmbedding(AbstractType):
         "matrix_dtype": DTYPE_CHOICES,
     }
 
+class GraphSageNodeEmbedding(AbstractType):
+    pass
 
 del AbstractType, Wrapper

--- a/metagraph/wrappers.py
+++ b/metagraph/wrappers.py
@@ -227,6 +227,8 @@ class NodeEmbeddingWrapper(Wrapper, abstract=NodeEmbedding, register=False):
                 abs_tol=abs_tol,
             )
 
-class GraphSageNodeEmbeddingWrapper(Wrapper, abstract=GraphSageNodeEmbedding, register=False):
-    pass
 
+class GraphSageNodeEmbeddingWrapper(
+    Wrapper, abstract=GraphSageNodeEmbedding, register=False
+):
+    pass

--- a/metagraph/wrappers.py
+++ b/metagraph/wrappers.py
@@ -9,6 +9,7 @@ from .types import (
     Graph,
     BipartiteGraph,
     NodeEmbedding,
+    GraphSageNodeEmbedding,
 )
 from typing import Set, Dict, Any
 
@@ -225,3 +226,7 @@ class NodeEmbeddingWrapper(Wrapper, abstract=NodeEmbedding, register=False):
                 rel_tol=rel_tol,
                 abs_tol=abs_tol,
             )
+
+class GraphSageNodeEmbeddingWrapper(Wrapper, abstract=GraphSageNodeEmbedding, register=False):
+    pass
+


### PR DESCRIPTION
This commit adds a test and abstract algorithm for `embedding.train.graphwave`.

This commit also adds an `as_dense` method to `NumpyVector` that returns a 1-D NumPy array.
