### PR TITLE
Make transductive node embeddings return Tuple[Matrix, NodeMap]

### DIFF
--- a/metagraph/__init__.py
+++ b/metagraph/__init__.py
@@ -15,7 +15,7 @@ from .core.plugin import (
 from .core import dtypes
 from .core.plugin_registry import PluginRegistry
 from .core.node_labels import NodeLabels
-from .core.typing import Union, Optional
+from .core.typing import Union, Optional, List
 from .types import NodeID
 from . import types, algorithms
 

--- a/metagraph/algorithms/embedding.py
+++ b/metagraph/algorithms/embedding.py
@@ -63,3 +63,16 @@ def graph_sage_mean_train(
 ) -> GraphSageNodeEmbedding:
     # returned embeddings will have size equal to layer_sizes[-1]
     pass  # pragma: no cover
+
+
+@abstract_algorithm("embedding.train.line")
+def line_train(
+    graph: Graph,
+    walks_per_node: int,
+    negative_sample_count: int,
+    embedding_size: int,
+    epochs: int,
+    learning_rate: float,
+    batch_size: int,
+) -> Tuple[Matrix, NodeMap]:
+    pass  # pragma: no cover

--- a/metagraph/algorithms/embedding.py
+++ b/metagraph/algorithms/embedding.py
@@ -1,5 +1,6 @@
 from metagraph import abstract_algorithm
-from metagraph.types import Graph, Vector, NodeEmbedding, GraphSageNodeEmbedding
+from metagraph.types import Graph, Matrix, Vector, NodeMap, GraphSageNodeEmbedding
+from typing import Tuple
 
 
 @abstract_algorithm("embedding.train.node2vec")
@@ -12,7 +13,7 @@ def node2vec_train(
     embedding_size: int,
     epochs: int,
     learning_rate: float,
-) -> NodeEmbedding:
+) -> Tuple[Matrix, NodeMap]:
     pass  # pragma: no cover
 
 
@@ -23,14 +24,14 @@ def graphwave_train(
     sample_point_count: int,
     sample_point_max: float,
     chebyshev_degree: int,
-) -> NodeEmbedding:
+) -> Tuple[Matrix, NodeMap]:
     pass  # pragma: no cover
 
 
 @abstract_algorithm("embedding.train.hope.katz")
 def hope_katz_train(
     graph: Graph(edge_type="map", is_directed=True), embedding_size: int, beta: float
-) -> NodeEmbedding:
+) -> Tuple[Matrix, NodeMap]:
     # embedding_size is ideally even since HOPE learns 2 embedding vectors of size embedding_size // 2 and concatenates them
     pass  # pragma: no cover
 
@@ -38,7 +39,8 @@ def hope_katz_train(
 @abstract_algorithm("embedding.train.graph_sage.mean")
 def graph_sage_mean_train(
     graph: Graph(edge_type="map", is_directed=True),
-    node_features: NodeEmbedding,
+    node_features: Matrix,
+    node2row: NodeMap,
     walk_length: int,
     walks_per_node: int,
     layer_sizes: Vector,

--- a/metagraph/algorithms/embedding.py
+++ b/metagraph/algorithms/embedding.py
@@ -1,3 +1,4 @@
+import metagraph as mg
 from metagraph import abstract_algorithm
 from metagraph.types import Graph, Matrix, Vector, NodeMap, GraphSageNodeEmbedding
 from typing import Tuple
@@ -14,6 +15,17 @@ def node2vec_train(
     epochs: int,
     learning_rate: float,
 ) -> Tuple[Matrix, NodeMap]:
+    pass  # pragma: no cover
+
+
+@abstract_algorithm("embedding.train.graph2vec")
+def graph2vec_train(
+    graphs: mg.List[Graph(edge_type="set", is_directed=False)],
+    subgraph_degree: int,
+    embedding_size: int,
+    epochs: int,
+    learning_rate: float,
+) -> Matrix:
     pass  # pragma: no cover
 
 

--- a/metagraph/algorithms/utility.py
+++ b/metagraph/algorithms/utility.py
@@ -9,7 +9,6 @@ from metagraph.types import (
     EdgeSet,
     EdgeMap,
     Graph,
-    NodeEmbedding,
     GraphSageNodeEmbedding,
 )
 from typing import Any, Tuple, Callable
@@ -124,12 +123,15 @@ def graph_isomorphic(g1: Graph, g2: Graph) -> bool:
 
 
 @abstract_algorithm("util.node_embedding.apply")
-def node_embedding_apply(embedding: NodeEmbedding, nodes: Vector) -> Matrix:
+def node_embedding_apply(matrix: Matrix, node2row: NodeMap, nodes: Vector) -> Matrix:
     pass  # pragma: no cover
 
 
 @abstract_algorithm("util.graph_sage_node_embedding.apply")
 def graph_sage_node_embedding_apply(
-    embedding: GraphSageNodeEmbedding, graph: Graph, node_features: NodeEmbedding
+    embedding: GraphSageNodeEmbedding,
+    graph: Graph,
+    node_features: Matrix,
+    node2row: NodeMap,
 ) -> Matrix:
     pass  # pragma: no cover

--- a/metagraph/core/multiverify.py
+++ b/metagraph/core/multiverify.py
@@ -273,8 +273,8 @@ class MultiVerify:
             except Exception:
                 print(f"[{algo_path}] Performing custom compare against:")
                 if not isinstance(result, tuple):
-                    ret_val = (result,)
-                for item in ret_val:
+                    result = (result,)
+                for item in result:
                     if hasattr(item, "value"):
                         print(item.value)
                     else:

--- a/metagraph/plugins/numpy/algorithms.py
+++ b/metagraph/plugins/numpy/algorithms.py
@@ -6,7 +6,6 @@ from .types import (
     NumpyMatrix,
     NumpyNodeMap,
     NumpyNodeSet,
-    NumpyNodeEmbedding,
 )
 from typing import Any, Callable, Optional
 from .. import has_numba
@@ -129,8 +128,8 @@ def np_nodemap_reduce(x: NumpyNodeMap, func: Callable[[Any, Any], Any]) -> Any:
 
 @concrete_algorithm("util.node_embedding.apply")
 def np_embedding_apply(
-    embedding: NumpyNodeEmbedding, nodes: NumpyVector
+    matrix: NumpyMatrix, node2row: NumpyNodeMap, nodes: NumpyVector
 ) -> NumpyMatrix:
-    indices = embedding.nodes[nodes.value]
-    matrix = embedding.matrix.value[indices]
+    indices = node2row[nodes.value]
+    matrix = matrix.value[indices]
     return NumpyMatrix(matrix)

--- a/metagraph/plugins/numpy/types.py
+++ b/metagraph/plugins/numpy/types.py
@@ -1,8 +1,8 @@
 from typing import Set, Dict, Any
 import numpy as np
 from metagraph import dtypes, Wrapper
-from metagraph.types import Vector, Matrix, NodeSet, NodeMap, NodeEmbedding
-from metagraph.wrappers import NodeSetWrapper, NodeMapWrapper, NodeEmbeddingWrapper
+from metagraph.types import Vector, Matrix, NodeSet, NodeMap
+from metagraph.wrappers import NodeSetWrapper, NodeMapWrapper
 
 
 class NumpyNodeSet(NodeSetWrapper, abstract=NodeSet):
@@ -479,20 +479,3 @@ class NumpyMatrix(Wrapper, abstract=Matrix):
                     assert np.isclose(d1, d2, rtol=rel_tol, atol=abs_tol).all().all()
                 else:
                     assert (d1 == d2).all().all()
-
-
-class NumpyNodeEmbedding(NodeEmbeddingWrapper, abstract=NodeEmbedding):
-    def __init__(self, matrix, nodes=None):
-        super().__init__(matrix, nodes)
-        self._assert_instance(matrix, NumpyMatrix)
-        if nodes is not None:
-            self._assert_instance(nodes, NumpyNodeMap)
-            self._assert(
-                len(nodes) == matrix.value.shape[0],
-                f"Node count ({len(nodes)}) and matrix row count ({matrix.value.shape[0]})do not match.",
-            )
-
-    def copy(self):
-        nodes = None if self.nodes is None else self.nodes.copy()
-        matrix = NumpyMatrix(self.matrix.as_dense(copy=True))
-        return NumpyNodeEmbedding(matrix, nodes=nodes)

--- a/metagraph/tests/algorithms/test_embedding.py
+++ b/metagraph/tests/algorithms/test_embedding.py
@@ -79,8 +79,8 @@ def test_graph2vec(default_plugin_resolver):
     nx_graphs = complete_graphs + path_graphs + random_graphs
     graphs = list(map(dpr.wrappers.Graph.NetworkXGraph, nx_graphs))
     subgraph_degree = 10
-    embedding_size = 2
-    epochs = 8
+    embedding_size = 12
+    epochs = 10
     learning_rate = 5e-2
 
     def cmp_func(matrix):
@@ -235,3 +235,172 @@ def test_graphwave(default_plugin_resolver):
 #     embedding.normalize(dpr.types.NodeEmbedding.NumpyNodeEmbeddingType).custom_compare(
 #         cmp_func
 #     )
+
+
+def test_graph_sage_mean(default_plugin_resolver):
+    """
+== Training Subgraph ==
+
+[Training Subgraph A (fully connected), nodes 0..9] --------------|
+                           |                                      |
+                    node 9999_09_10                               |
+                           |                                      |
+[Training Subgraph B (fully connected), nodes 10..19]     node 9999_29_00
+                           |                                      |
+                    node 9999_19_20                               |
+                           |                                      |
+[Training Subgraph C (fully connected), nodes 10..19] -------------
+
+Training Subgraph A nodes all have feature vector [1, 0, 0, 0, 0, ..., 0]
+Training Subgraph B nodes all have feature vector [0, 1, 0, 0, 0, ..., 0]
+Training Subgraph C nodes all have feature vector [0, 0, 1, 0, 0, ..., 0]
+Nodes 9999_09_10, 9999_19_20, and node 9999_29_00 have the zero vector as their node features.
+
+
+
+== Testing Subgraph ==
+
+[Testing Subgraph A (fully connected), nodes 8888_00..8888_19]
+                        |
+                 node 8888_00_20
+                        |
+[Testing Subgraph B (fully connected), nodes 8888_20..8888_49]
+
+Testing Subgraph A nodes all have feature vector [1, 0, 0, 0, 0, ..., 0]
+Testing Subgraph B nodes all have feature vector [0, 1, 0, 0, 0, ..., 0]
+Node 8888_00_20 hsa the zero vector as a its node features.
+
+
+
+== Differences Between Training & Testing Graphs ==
+
+All the complete subgraphs in the training graph have 10 nodes, but the complete subgraphs in the testing graph do NOT.
+
+The test verifies for the testing graph that the 20 nearest neighbors in the embedding space of each node are all part of the same complete subgraph.
+    """
+
+    try:
+        from sklearn.neighbors import NearestNeighbors
+    except:
+        pytest.skip("scikit-learn not installed.")
+
+    if "metagraph_stellargraph" not in dir(default_plugin_resolver.plugins):
+        pytest.skip("metagraph_stellargraph not installed.")
+
+    dpr = default_plugin_resolver
+
+    # Generate Training Graph
+    a_nodes = np.arange(10)
+    b_nodes = np.arange(10, 20)
+    c_nodes = np.arange(20, 30)
+
+    complete_graph_a = nx.complete_graph(a_nodes)
+    complete_graph_b = nx.complete_graph(b_nodes)
+    complete_graph_c = nx.complete_graph(c_nodes)
+
+    nx_graph = nx.compose(
+        nx.compose(complete_graph_a, complete_graph_b), complete_graph_c
+    )
+    nx_graph.add_edge(9999_09_10, 9)
+    nx_graph.add_edge(9999_09_10, 10)
+    nx_graph.add_edge(9999_19_20, 19)
+    nx_graph.add_edge(9999_19_20, 20)
+    nx_graph.add_edge(9999_29_00, 29)
+    nx_graph.add_edge(9999_29_00, 0)
+
+    graph = dpr.wrappers.Graph.NetworkXGraph(nx_graph)
+
+    mv = MultiVerify(dpr)
+
+    embedding_size = 50
+    node_feature_nodes = dpr.wrappers.NodeMap.NumpyNodeMap(
+        np.arange(33),
+        node_ids=np.concatenate(
+            [np.arange(30), np.array([9999_09_10, 9999_19_20, 9999_29_00])]
+        ),
+    )
+    node_feature_np_matrix = np.zeros([33, embedding_size])
+    node_feature_np_matrix[a_nodes, 0] = 1
+    node_feature_np_matrix[b_nodes, 1] = 1
+    node_feature_np_matrix[c_nodes, 2] = 1
+    node_feature_np_matrix[30:] = np.ones(embedding_size)
+    node_feature_matrix = dpr.wrappers.Matrix.NumpyMatrix(node_feature_np_matrix)
+
+    # Run GraphSAGE
+    walk_length = 5
+    walks_per_node = 1
+    layer_sizes = dpr.wrappers.Vector.NumpyVector(np.array([40, 30]))
+    samples_per_layer = dpr.wrappers.Vector.NumpyVector(np.array([10, 5]))
+    epochs = 35
+    learning_rate = 5e-3
+    batch_size = 2
+
+    assert len(layer_sizes) == len(samples_per_layer)
+
+    embedding = mv.compute(
+        "embedding.train.graph_sage.mean",
+        graph,
+        node_feature_matrix,
+        node_feature_nodes,
+        walk_length,
+        walks_per_node,
+        layer_sizes,
+        samples_per_layer,
+        epochs,
+        learning_rate,
+        batch_size,
+    ).normalize(dpr.types.GraphSageNodeEmbedding.StellarGraphGraphSageNodeEmbeddingType)
+
+    # Create Testing Graph
+    unseen_a_nodes = np.arange(8888_00, 8888_20)
+    unseen_b_nodes = np.arange(8888_20, 8888_50)
+    unseen_complete_graph_a = nx.complete_graph(unseen_a_nodes)
+    unseen_complete_graph_b = nx.complete_graph(unseen_b_nodes)
+    unseen_nx_graph = nx.compose(unseen_complete_graph_a, unseen_complete_graph_b)
+    unseen_nx_graph.add_edge(8888_00_20, 8888_00)
+    unseen_nx_graph.add_edge(8888_00_20, 8888_20)
+    unseen_node_feature_np_matrix = np.zeros([51, embedding_size])
+    unseen_node_feature_np_matrix[0:20, 0] = 1
+    unseen_node_feature_np_matrix[20:50, 1] = 1
+    unseen_node_feature_matrix = dpr.wrappers.Matrix.NumpyMatrix(
+        unseen_node_feature_np_matrix
+    )
+    unseen_node_feature_nodes = dpr.wrappers.NodeMap.NumpyNodeMap(
+        np.arange(51),
+        node_ids=np.concatenate(
+            [unseen_a_nodes, unseen_b_nodes, np.array([8888_00_20])]
+        ),
+    )
+    unseen_graph = dpr.wrappers.Graph.NetworkXGraph(unseen_nx_graph)
+    matrix = mv.transform(
+        dpr.plugins.metagraph_stellargraph.algos.util.graph_sage_node_embedding.apply,
+        embedding,
+        unseen_graph,
+        unseen_node_feature_matrix,
+        unseen_node_feature_nodes,
+        batch_size=batch_size,
+        worker_count=1,
+    )
+
+    # Verify GraphSAGE results
+    def cmp_func(matrix):
+        assert tuple(matrix.shape) == (51, layer_sizes.as_dense(copy=False)[-1])
+        np_matrix = matrix.as_dense(copy=False)
+        unseen_a_vectors = np_matrix[0:20]
+        unseen_b_vectors = np_matrix[20:50]
+
+        _, neighbor_indices = (
+            NearestNeighbors(n_neighbors=20).fit(np_matrix).kneighbors(np_matrix)
+        )
+
+        for unseen_a_node_position in range(20):
+            unseen_a_node_neighbor_indices = neighbor_indices[unseen_a_node_position]
+            for unseen_a_node_neighbor_index in unseen_a_node_neighbor_indices:
+                assert 0 <= unseen_a_node_neighbor_index < 20
+
+        for unseen_b_node_position in range(20, 50):
+            unseen_b_node_neighbor_indices = neighbor_indices[unseen_b_node_position]
+            for unseen_b_node_neighbor_index in unseen_b_node_neighbor_indices:
+                assert 20 <= unseen_b_node_neighbor_index < 50
+
+    matrix.normalize(dpr.types.Matrix.NumpyMatrixType).custom_compare(cmp_func)

--- a/metagraph/tests/algorithms/test_embedding.py
+++ b/metagraph/tests/algorithms/test_embedding.py
@@ -1,4 +1,5 @@
 from metagraph.tests.util import default_plugin_resolver
+import pytest
 import networkx as nx
 import numpy as np
 import math

--- a/metagraph/tests/algorithms/test_embedding.py
+++ b/metagraph/tests/algorithms/test_embedding.py
@@ -68,7 +68,7 @@ def test_node2vec(default_plugin_resolver):
 def test_graph2vec(default_plugin_resolver):
     try:
         from sklearn.mixture import GaussianMixture
-    except:
+    except ModuleNotFoundError:
         pytest.skip("scikit-learn not installed.")
 
     dpr = default_plugin_resolver
@@ -191,7 +191,7 @@ def test_graphwave(default_plugin_resolver):
 def test_hope_katz(default_plugin_resolver):
     try:
         from sklearn.mixture import GaussianMixture
-    except:
+    except ModuleNotFoundError:
         pytest.skip("scikit-learn not installed.")
 
     dpr = default_plugin_resolver
@@ -314,7 +314,7 @@ The test verifies for the testing graph that the 20 nearest neighbors in the emb
 
     try:
         from sklearn.neighbors import NearestNeighbors
-    except:
+    except ModuleNotFoundError:
         pytest.skip("scikit-learn not installed.")
 
     if "metagraph_stellargraph" not in dir(default_plugin_resolver.plugins):
@@ -442,7 +442,7 @@ The test verifies for the testing graph that the 20 nearest neighbors in the emb
 def test_line(default_plugin_resolver):
     try:
         from sklearn.mixture import GaussianMixture
-    except:
+    except ModuleNotFoundError:
         pytest.skip("scikit-learn not installed.")
 
     dpr = default_plugin_resolver

--- a/metagraph/tests/algorithms/test_utility.py
+++ b/metagraph/tests/algorithms/test_utility.py
@@ -508,31 +508,33 @@ def test_edgemap_from_edgeset(default_plugin_resolver):
 
 def test_node_embedding_apply(default_plugin_resolver):
     dpr = default_plugin_resolver
-    matrix = np.arange(6).reshape(2, 3)
-    matrix = dpr.wrappers.Matrix.NumpyMatrix(matrix)
-    nodes = dpr.wrappers.NodeMap.NumpyNodeMap(
+    matrix = dpr.wrappers.Matrix.NumpyMatrix(np.arange(6).reshape(2, 3))
+    node_map = dpr.wrappers.NodeMap.NumpyNodeMap(
         np.array([0, 1]), node_ids=np.array([9990, 9991])
     )
-    embedding = dpr.wrappers.NodeEmbedding.NumpyNodeEmbedding(matrix, nodes)
 
     MultiVerify(dpr).compute(
         "util.node_embedding.apply",
-        embedding,
+        matrix,
+        node_map,
         dpr.wrappers.Vector.NumpyVector(np.array([9990])),
     ).assert_equal(dpr.wrappers.Matrix.NumpyMatrix(np.array([[0, 1, 2]])))
     MultiVerify(dpr).compute(
         "util.node_embedding.apply",
-        embedding,
+        matrix,
+        node_map,
         dpr.wrappers.Vector.NumpyVector(np.array([9991])),
     ).assert_equal(dpr.wrappers.Matrix.NumpyMatrix(np.array([[3, 4, 5]])))
     MultiVerify(dpr).compute(
         "util.node_embedding.apply",
-        embedding,
+        matrix,
+        node_map,
         dpr.wrappers.Vector.NumpyVector(np.array([9990, 9991])),
     ).assert_equal(matrix)
     MultiVerify(dpr).compute(
         "util.node_embedding.apply",
-        embedding,
+        matrix,
+        node_map,
         dpr.wrappers.Vector.NumpyVector(np.array([9991, 9990])),
     ).assert_equal(dpr.wrappers.Matrix.NumpyMatrix(np.array([[3, 4, 5], [0, 1, 2]])))
 

--- a/metagraph/types.py
+++ b/metagraph/types.py
@@ -128,12 +128,6 @@ class BipartiteGraph(AbstractType):
 #################################
 # Embedding
 #################################
-class NodeEmbedding(AbstractType):
-    properties = {
-        "matrix_dtype": DTYPE_CHOICES,
-    }
-
-
 class GraphSageNodeEmbedding(AbstractType):
     pass
 

--- a/metagraph/wrappers.py
+++ b/metagraph/wrappers.py
@@ -8,7 +8,6 @@ from .types import (
     # EdgeTable,
     Graph,
     BipartiteGraph,
-    NodeEmbedding,
     GraphSageNodeEmbedding,
 )
 from typing import Set, Dict, Any
@@ -150,82 +149,6 @@ class CompositeGraphWrapper(GraphWrapper, abstract=Graph, register=False):
 
 class BipartiteGraphWrapper(Wrapper, abstract=BipartiteGraph, register=False):
     pass
-
-
-class NodeEmbeddingWrapper(Wrapper, abstract=NodeEmbedding, register=False):
-    def __init__(self, matrix, nodes=None):
-        super().__init__()
-        self._assert(
-            type(matrix).Type.compute_abstract_properties(matrix, {"is_dense"})[
-                "is_dense"
-            ],
-            f"Matrix {matrix} must be dense",
-        )
-        self.matrix = matrix
-        if nodes is not None:
-            nodes_dtype = type(nodes).Type.compute_abstract_properties(
-                nodes, {"dtype"}
-            )["dtype"]
-            self._assert(
-                nodes_dtype == "int",
-                f"Node map {nodes} must have dtype of int rather than {nodes_dtype}",
-            )
-        self.nodes = nodes
-
-    class TypeMixin:
-        @classmethod
-        def _compute_abstract_properties(
-            cls, obj, props: Set[str], known_props: Dict[str, Any]
-        ) -> Dict[str, Any]:
-            ret = known_props.copy()
-
-            # fast properties
-            for prop in {"matrix_dtype"} - ret.keys():
-                if prop == "matrix_dtype":
-                    ret[prop] = type(obj.matrix).Type.compute_abstract_properties(
-                        obj.matrix, {"dtype"}, {}
-                    )
-
-            return ret
-
-        @classmethod
-        def assert_equal(
-            cls,
-            obj1,
-            obj2,
-            aprops1,
-            aprops2,
-            cprops1,
-            cprops2,
-            *,
-            rel_tol=1e-9,
-            abs_tol=0.0,
-        ):
-            assert aprops1 == aprops2, f"property mismatch: {aprops1} != {aprops2}"
-
-            matrix_class = type(obj1.matrix).Type
-            matrix_class.assert_equal(
-                obj1.matrix,
-                obj2.matrix,
-                {"dtype": aprops1["matrix_dtype"]},
-                {"dtype": aprops2["matrix_dtype"]},
-                {},
-                {},
-                rel_tol=rel_tol,
-                abs_tol=abs_tol,
-            )
-
-            nodes_class = type(obj1.nodes).Type
-            nodes_class.assert_equal(
-                obj1.nodes,
-                obj2.nodes,
-                {},
-                {},
-                {},
-                {},
-                rel_tol=rel_tol,
-                abs_tol=abs_tol,
-            )
 
 
 class GraphSageNodeEmbeddingWrapper(


### PR DESCRIPTION
This commit makes it so that the following algorithms return a `Tuple[Matrix, NodeMap] .
* `embedding.train.node2vec`
* `embedding.train.graphwave`
* `embedding.train.hope.katz`

This commit also gets rid of the `NodeEmbedding` abstract type and concrete type in the `numpy` plugin.

Because of this, the signature for `embedding.train.graph_sage.mean` had to change as well.

Similarly, the signatures for `util.node_embedding.apply` and `util.graph_sage_node_embedding.apply` changed.

The tests were updated to account for the above changes.