### PR TITLE
Fix deployment workflow

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -82,7 +82,7 @@ jobs:
   dev_deploy:
     runs-on: ubuntu-latest
     needs: build
-    # if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -64,7 +64,6 @@ jobs:
           coveralls
       - name: Pre-Upload Artifact
         run: |
-          conda install -q anaconda-client
           # This doesn't rebuild, but simply computes the name of the file that was previously built
           OUTPUT=$(conda build --output -c defaults -c conda-forge --python ${{ matrix.pyver }} continuous_integration/conda)
           echo "Path to built package:"
@@ -92,6 +91,9 @@ jobs:
           path: ./artifact_storage
       - name: Deploy with dev label
         run: |
+          source "$CONDA/etc/profile.d/conda.sh"
+          conda activate mg
+          conda install -q anaconda-client
           ls -la ./artifact_storage
           UPLOAD=`ls ./artifact_storage | head -1`
           echo "Uploading $UPLOAD with label=dev"

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -97,4 +97,4 @@ jobs:
           ls -la ./artifact_storage
           UPLOAD=`ls ./artifact_storage | head -1`
           echo "Uploading $UPLOAD with label=dev"
-          $CONDA/bin/anaconda -t ${{ secrets.ANACONDA_ORG_TOKEN }} upload -u metagraph -l dev --no-progress --force --no-register $UPLOAD
+          $CONDA/bin/anaconda -t ${{ secrets.ANACONDA_ORG_TOKEN }} upload -u metagraph -l dev --no-progress --force --no-register ./artifact_storage/$UPLOAD

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -97,4 +97,4 @@ jobs:
           ls -la ./artifact_storage
           UPLOAD=`ls ./artifact_storage | head -1`
           echo "Uploading $UPLOAD with label=dev"
-          anaconda -t ${{ secrets.ANACONDA_ORG_TOKEN }} upload -u metagraph -l dev --no-progress --force --no-register $UPLOAD
+          $CONDA/bin/anaconda -t ${{ secrets.ANACONDA_ORG_TOKEN }} upload -u metagraph -l dev --no-progress --force --no-register $UPLOAD

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Deploy with dev label
         run: |
           source "$CONDA/etc/profile.d/conda.sh"
-          conda activate mg
+          conda config --set always_yes yes --set changeps1 no
           conda install -q anaconda-client
           ls -la ./artifact_storage
           UPLOAD=`ls ./artifact_storage | head -1`

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -82,7 +82,7 @@ jobs:
   dev_deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/master'
+    # if: github.ref == 'refs/heads/master'
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v2


### PR DESCRIPTION
This is being done in a base repo branch to allow secrets to be used during development rather than committing to master to test the effects.