### PR TITLE
Loosen contraints on test_line

### DIFF
--- a/metagraph/plugins/pandas/translators.py
+++ b/metagraph/plugins/pandas/translators.py
@@ -21,13 +21,15 @@ if has_pandas and has_scipy:
             "is_directed"
         ]
         coo_matrix = x.value.tocoo()
-        get_node_from_pos = lambda index: x.node_list[index]
-        row_ids = map(get_node_from_pos, coo_matrix.row)
-        column_ids = map(get_node_from_pos, coo_matrix.col)
-        rcw_triples = zip(row_ids, column_ids, coo_matrix.data)
+        row_ids = x.node_list[coo_matrix.row]
+        column_ids = x.node_list[coo_matrix.col]
+        weights = coo_matrix.data
         if not is_directed:
-            rcw_triples = filter(lambda triple: triple[0] <= triple[1], rcw_triples)
-        df = pd.DataFrame(rcw_triples, columns=["source", "target", "weight"])
+            mask = row_ids <= column_ids
+            row_ids = row_ids[mask]
+            column_ids = column_ids[mask]
+            weights = weights[mask]
+        df = pd.DataFrame({"source": row_ids, "target": column_ids, "weight": weights})
         return PandasEdgeMap(df, is_directed=is_directed)
 
     @translator
@@ -36,11 +38,11 @@ if has_pandas and has_scipy:
             "is_directed"
         ]
         coo_matrix = x.value.tocoo()
-        get_node_from_pos = lambda index: x.node_list[index]
-        row_ids = map(get_node_from_pos, coo_matrix.row)
-        column_ids = map(get_node_from_pos, coo_matrix.col)
-        rc_pairs = zip(row_ids, column_ids)
+        row_ids = x.node_list[coo_matrix.row]
+        column_ids = x.node_list[coo_matrix.col]
         if not is_directed:
-            rc_pairs = filter(lambda pair: pair[0] <= pair[1], rc_pairs)
-        df = pd.DataFrame(rc_pairs, columns=["source", "target"])
+            mask = row_ids <= column_ids
+            row_ids = row_ids[mask]
+            column_ids = column_ids[mask]
+        df = pd.DataFrame({"source": row_ids, "target": column_ids})
         return PandasEdgeSet(df, is_directed=is_directed)

--- a/metagraph/tests/algorithms/test_embedding.py
+++ b/metagraph/tests/algorithms/test_embedding.py
@@ -3,6 +3,7 @@ import pytest
 import networkx as nx
 import numpy as np
 import math
+from collections import defaultdict
 
 from . import MultiVerify
 
@@ -485,13 +486,14 @@ def test_line(default_plugin_resolver):
         b_labels = predicted_labels[b_indices]
         c_labels = predicted_labels[c_indices]
 
-        assert len(np.unique(a_labels)) == 1
-        assert len(np.unique(b_labels)) == 1
-        assert len(np.unique(c_labels)) == 1
+        a_label = int(np.median(a_labels))
+        b_label = int(np.median(b_labels))
+        c_label = int(np.median(c_labels))
 
-        a_label = a_labels[0]
-        b_label = b_labels[0]
-        c_label = c_labels[0]
+        assert np.sum(a_labels == a_label) / len(a_labels) > 0.95
+        assert np.sum(b_labels == b_label) / len(b_labels) > 0.95
+        assert np.sum(c_labels == c_label) / len(c_labels) > 0.95
+
         a_variances = np.sum(gmm.covariances_[a_label] * np.eye(embedding_size), axis=0)
         b_variances = np.sum(gmm.covariances_[b_label] * np.eye(embedding_size), axis=0)
         c_variances = np.sum(gmm.covariances_[c_label] * np.eye(embedding_size), axis=0)


### PR DESCRIPTION
test_line fails about 1/10 times due to random initializations paired with overly strict constraints/testing assertions.

This PR loosens the constraints required by `test_line` slightly.

It also includes some optimizations for the Pandas translators.