### PR TITLE
Remove unnecessary translations to CSR in SciPy translators

### DIFF
--- a/metagraph/core/roundtrip.py
+++ b/metagraph/core/roundtrip.py
@@ -168,7 +168,7 @@ class RoundTripper:
             ), f"Translation from {target} to {ct_obj} returned an object of type {ct_unverified}"
             assert (
                 aprops_unverified == aprops_obj
-            ), f"Translated object of type {ct_unverified} has wrong properties {aprops_unverified}"
+            ), f"Translated object of type {ct_unverified} has wrong properties {aprops_unverified} (expected {aprops_obj})"
             # Verify equal to `obj`
             waypoints = [prep_plan.src_type] + prep_plan.dst_types
             waypoints = waypoints[:-1] + [source, target] + return_plan.dst_types

--- a/metagraph/explorer/api.py
+++ b/metagraph/explorer/api.py
@@ -471,4 +471,4 @@ def solve_algorithm(
                             },
                         }
                         break
-        return solutions
+    return solutions

--- a/metagraph/plugins/scipy/translators.py
+++ b/metagraph/plugins/scipy/translators.py
@@ -130,7 +130,7 @@ if has_scipy and has_pandas:
         matrix = ss.coo_matrix(
             (weights, (source_positions, target_positions)),
             shape=(num_nodes, num_nodes),
-        ).tocsr()
+        )
         return ScipyEdgeMap(matrix, node_list, aprops={"is_directed": is_directed})
 
     @translator
@@ -152,5 +152,5 @@ if has_scipy and has_pandas:
         matrix = ss.coo_matrix(
             (np.ones(len(source_positions)), (source_positions, target_positions)),
             shape=(num_nodes, num_nodes),
-        ).tocsr()
+        )
         return ScipyEdgeSet(matrix, node_list, aprops={"is_directed": is_directed})


### PR DESCRIPTION
It's not always clear cut if COO or CSR is the best format for the matrix of a SciPy graph. The translators used to always convert to CSR. It now does not do that since it's unclear if the translation cost is warranted.