### PR TITLE
Various bugfixes, new tests, and cleanup

### DIFF
--- a/metagraph/algorithms/clustering.py
+++ b/metagraph/algorithms/clustering.py
@@ -36,7 +36,7 @@ def triangle_count(graph: Graph(is_directed=False)) -> int:
 def global_clustering_coefficient(graph: Graph(is_directed=False)) -> float:
     """
     Return the global clustering coefficient.
-    
+
     global_clustering_coefficient = num_closed_triplets / num_triplets
 
     A triplet in a graph is a subgraph of 3 nodes where at least 2 edges are present.
@@ -44,7 +44,7 @@ def global_clustering_coefficient(graph: Graph(is_directed=False)) -> float:
     An open triplet has exactly 2 edges.
 
     A closed triplet has exactly 3 edges.
-    
+
     The more details can be found at https://en.wikipedia.org/wiki/Clustering_coefficient#Global_clustering_coefficient
     """
     pass  # pragma: no cover

--- a/metagraph/algorithms/traversal.py
+++ b/metagraph/algorithms/traversal.py
@@ -81,7 +81,7 @@ def astar_search(
 ) -> Vector:
     """
     heuristic_func is a unary function returning the distance between a given node and the target node.
-    
+
     The return value is a vector of node ids representing the non-unique path found by the A* algorithm.
     """
     pass  # pragma: no cover

--- a/metagraph/algorithms/utility.py
+++ b/metagraph/algorithms/utility.py
@@ -72,7 +72,7 @@ def graph_aggregate_edges(
     out_edges: bool = True,
 ) -> NodeMap:
     """
-    if in_edges == out_edges == False, every node is mapped to initial_value 
+    if in_edges == out_edges == False, every node is mapped to initial_value
     if the graph is undirected and either in_edges == True or out_edges == True, we aggregate over all of the edges for each node exactly once to avoid double counting
     if the graph is directed, in_edges and out_edges specify which edge types to aggregate over for a given node
     """

--- a/metagraph/core/multiverify.py
+++ b/metagraph/core/multiverify.py
@@ -320,7 +320,7 @@ class MultiVerify:
                         expected_val_elem, ret_val_elem, algo_path, rel_tol, abs_tol
                     )
             else:
-                self.compare_values(expected_val, result, algo_path, rel_tol, abs_tol)
+                self.compare_values(result, expected_val, algo_path, rel_tol, abs_tol)
 
     def compare_values(self, val, expected_val, algo_path, rel_tol=1e-9, abs_tol=0.0):
         expected_val = ensure_computed(expected_val)

--- a/metagraph/core/plugin_registry.py
+++ b/metagraph/core/plugin_registry.py
@@ -24,7 +24,7 @@ class PluginRegistry:
     # /plugins.py
     registry = metagraph.plugin_registry.PluginRegistry()
     def find_plugins():
-        from . import graphblas, 
+        from . import graphblas,
         registry.register_from_modules(metagraph.types, metagraph.algorithms)
         registry.register_from_modules(graphblas, name="core_graphblas")
         ...

--- a/metagraph/plugins/graphblas/translators.py
+++ b/metagraph/plugins/graphblas/translators.py
@@ -120,7 +120,7 @@ if has_grblas and has_scipy:
             x, {"node_type", "edge_type", "node_dtype", "edge_dtype", "is_directed"}
         )
 
-        size = int(x.node_list.max() + 1)
+        size = int(x.node_list.max()) + 1
 
         if aprops["node_type"] == "map":
             dtype = dtype_mg_to_grblas[x.node_vals.dtype]

--- a/metagraph/plugins/graphblas/translators.py
+++ b/metagraph/plugins/graphblas/translators.py
@@ -120,7 +120,7 @@ if has_grblas and has_scipy:
             x, {"node_type", "edge_type", "node_dtype", "edge_dtype", "is_directed"}
         )
 
-        size = x.node_list.max() + 1
+        size = int(x.node_list.max() + 1)
 
         if aprops["node_type"] == "map":
             dtype = dtype_mg_to_grblas[x.node_vals.dtype]

--- a/metagraph/plugins/pandas/types.py
+++ b/metagraph/plugins/pandas/types.py
@@ -64,7 +64,7 @@ if has_pandas:
                     .set_index([dst_label, src_label])
                     .index
                 )
-                dups = self.index & rev_index
+                dups = self.index.intersection(rev_index)
                 if len(dups) > 0:
                     raise ValueError(
                         f"is_directed=False, but duplicate edges found: {dups}"
@@ -115,17 +115,17 @@ if has_pandas:
                 g2 = obj2.value
                 assert len(g1) == len(g2), f"{len(g1)} != {len(g2)}"
                 if aprops1["is_directed"]:
-                    assert len(obj1.index & obj2.index) == len(
+                    assert len(obj1.index.intersection(obj2.index)) == len(
                         obj1.index
-                    ), f"edge mismatch {obj1.index ^ obj2.index}"
+                    ), f"edge mismatch {obj1.index.symmetric_difference(obj2.index)}"
                 else:  # undirected
                     rev1 = g1.set_index([obj1.dst_label, obj1.src_label])
                     rev2 = g2.set_index([obj2.dst_label, obj2.src_label])
-                    full1 = obj1.index | rev1.index
-                    full2 = obj2.index | rev2.index
-                    assert len(full1 & full2) == len(
+                    full1 = obj1.index.union(rev1.index)
+                    full2 = obj2.index.union(rev2.index)
+                    assert len(full1.intersection(full2)) == len(
                         full1
-                    ), f"edge mismatch {full1 ^ full2}"
+                    ), f"edge mismatch {full1.symmetric_difference(full2)}"
 
     class PandasEdgeMap(EdgeMapWrapper, abstract=EdgeMap):
         """
@@ -175,7 +175,7 @@ if has_pandas:
                     .set_index([dst_label, src_label])
                     .index
                 )
-                dups = self.index & rev_index
+                dups = self.index.intersection(rev_index)
                 if len(dups) > 0:
                     raise ValueError(
                         f"is_directed=False, but duplicate edges found: {dups}"
@@ -249,17 +249,17 @@ if has_pandas:
                 assert len(g1) == len(g2), f"{len(g1)} != {len(g2)}"
 
                 if aprops1["is_directed"]:
-                    assert len(obj1.index & obj2.index) == len(
+                    assert len(obj1.index.intersection(obj2.index)) == len(
                         obj1.index
-                    ), f"edge mismatch {obj1.index ^ obj2.index}"
+                    ), f"edge mismatch {obj1.index.symmetric_difference(obj2.index)}"
                 else:  # undirected
                     rev1 = g1.set_index([obj1.dst_label, obj1.src_label])
                     rev2 = g2.set_index([obj2.dst_label, obj2.src_label])
-                    full1 = obj1.index | rev1.index
-                    full2 = obj2.index | rev2.index
-                    assert len(full1 & full2) == len(
+                    full1 = obj1.index.union(rev1.index)
+                    full2 = obj2.index.union(rev2.index)
+                    assert len(full1.intersection(full2)) == len(
                         full1
-                    ), f"edge mismatch {full1 ^ full2}"
+                    ), f"edge mismatch {full1.symmetric_difference(full2)}"
 
                 # Ensure dataframes are indexed the same
                 if not (obj1.index == obj2.index).all():

--- a/metagraph/tests/algorithms/test_centrality.py
+++ b/metagraph/tests/algorithms/test_centrality.py
@@ -170,6 +170,11 @@ def test_pagerank_centrality(default_plugin_resolver):
         dpr.algos.centrality.pagerank, graph, tolerance=1e-7
     ).assert_equal(expected_val, rel_tol=1e-5)
 
+    # Test that hitting maxiter doesn't raise error
+    MultiVerify(dpr).compute(
+        dpr.algos.centrality.pagerank, graph, tolerance=1e-9, maxiter=2
+    )
+
 
 def test_closeness_centrality(default_plugin_resolver):
     dpr = default_plugin_resolver

--- a/metagraph/tests/algorithms/test_embedding.py
+++ b/metagraph/tests/algorithms/test_embedding.py
@@ -270,44 +270,44 @@ def test_hope_katz(default_plugin_resolver):
 
 def test_graph_sage_mean(default_plugin_resolver):
     """
-== Training Subgraph ==
+    == Training Subgraph ==
 
-[Training Subgraph A (fully connected), nodes 0..9] --------------|
-                           |                                      |
-                    node 9999_09_10                               |
-                           |                                      |
-[Training Subgraph B (fully connected), nodes 10..19]     node 9999_29_00
-                           |                                      |
-                    node 9999_19_20                               |
-                           |                                      |
-[Training Subgraph C (fully connected), nodes 10..19] -------------
+    [Training Subgraph A (fully connected), nodes 0..9] --------------|
+                               |                                      |
+                        node 9999_09_10                               |
+                               |                                      |
+    [Training Subgraph B (fully connected), nodes 10..19]     node 9999_29_00
+                               |                                      |
+                        node 9999_19_20                               |
+                               |                                      |
+    [Training Subgraph C (fully connected), nodes 10..19] -------------
 
-Training Subgraph A nodes all have feature vector [1, 0, 0, 0, 0, ..., 0]
-Training Subgraph B nodes all have feature vector [0, 1, 0, 0, 0, ..., 0]
-Training Subgraph C nodes all have feature vector [0, 0, 1, 0, 0, ..., 0]
-Nodes 9999_09_10, 9999_19_20, and node 9999_29_00 have the zero vector as their node features.
-
-
-
-== Testing Subgraph ==
-
-[Testing Subgraph A (fully connected), nodes 8888_00..8888_19]
-                        |
-                 node 8888_00_20
-                        |
-[Testing Subgraph B (fully connected), nodes 8888_20..8888_49]
-
-Testing Subgraph A nodes all have feature vector [1, 0, 0, 0, 0, ..., 0]
-Testing Subgraph B nodes all have feature vector [0, 1, 0, 0, 0, ..., 0]
-Node 8888_00_20 hsa the zero vector as a its node features.
+    Training Subgraph A nodes all have feature vector [1, 0, 0, 0, 0, ..., 0]
+    Training Subgraph B nodes all have feature vector [0, 1, 0, 0, 0, ..., 0]
+    Training Subgraph C nodes all have feature vector [0, 0, 1, 0, 0, ..., 0]
+    Nodes 9999_09_10, 9999_19_20, and node 9999_29_00 have the zero vector as their node features.
 
 
 
-== Differences Between Training & Testing Graphs ==
+    == Testing Subgraph ==
 
-All the complete subgraphs in the training graph have 10 nodes, but the complete subgraphs in the testing graph do NOT.
+    [Testing Subgraph A (fully connected), nodes 8888_00..8888_19]
+                            |
+                     node 8888_00_20
+                            |
+    [Testing Subgraph B (fully connected), nodes 8888_20..8888_49]
 
-The test verifies for the testing graph that the 20 nearest neighbors in the embedding space of each node are all part of the same complete subgraph.
+    Testing Subgraph A nodes all have feature vector [1, 0, 0, 0, 0, ..., 0]
+    Testing Subgraph B nodes all have feature vector [0, 1, 0, 0, 0, ..., 0]
+    Node 8888_00_20 hsa the zero vector as a its node features.
+
+
+
+    == Differences Between Training & Testing Graphs ==
+
+    All the complete subgraphs in the training graph have 10 nodes, but the complete subgraphs in the testing graph do NOT.
+
+    The test verifies for the testing graph that the 20 nearest neighbors in the embedding space of each node are all part of the same complete subgraph.
     """
 
     try:

--- a/metagraph/tests/algorithms/test_utility.py
+++ b/metagraph/tests/algorithms/test_utility.py
@@ -97,7 +97,7 @@ def test_nodemap_reduce(default_plugin_resolver):
     )
 
 
-def test_graph_degree(default_plugin_resolver):
+def test_graph_degree_directed(default_plugin_resolver):
     dpr = default_plugin_resolver
     #   0 1 2 3 4
     # 0 - 5 - - 2
@@ -127,6 +127,35 @@ def test_graph_degree(default_plugin_resolver):
     mv.compute("util.graph.degree", graph).assert_equal(e_out)
     mv.compute("util.graph.degree", graph, in_edges=True, out_edges=False).assert_equal(
         e_in
+    )
+    mv.compute("util.graph.degree", graph, in_edges=True, out_edges=True).assert_equal(
+        e_all
+    )
+    mv.compute(
+        "util.graph.degree", graph, in_edges=False, out_edges=False
+    ).assert_equal(e_none)
+
+
+def test_graph_degree_undirected(default_plugin_resolver):
+    dpr = default_plugin_resolver
+    #   0 1 2 3 4
+    # 0 - 5 1 - 2
+    # 1 5 - 2 - -
+    # 2 1 2 4 - 7
+    # 3 - - - - -
+    # 4 2 - 7 - -
+    g = nx.Graph()
+    g.add_nodes_from(range(5))
+    g.add_weighted_edges_from(
+        [(0, 1, 5), (0, 2, 1), (0, 4, 2), (1, 2, 2), (2, 2, 4), (2, 4, 7)]
+    )
+    graph = dpr.wrappers.Graph.NetworkXGraph(g)
+    e_all = {0: 3, 1: 2, 2: 5, 3: 0, 4: 2}
+    e_none = {i: 0 for i in range(5)}
+    mv = MultiVerify(dpr)
+    mv.compute("util.graph.degree", graph).assert_equal(e_all)
+    mv.compute("util.graph.degree", graph, in_edges=True, out_edges=False).assert_equal(
+        e_all
     )
     mv.compute("util.graph.degree", graph, in_edges=True, out_edges=True).assert_equal(
         e_all

--- a/metagraph/tests/test_multiverify.py
+++ b/metagraph/tests/test_multiverify.py
@@ -18,16 +18,16 @@ from metagraph.plugins.python.types import PythonNodeMapType
 
 def test_multiresult_consistent_length(default_plugin_resolver):
     mv = MultiVerify(default_plugin_resolver)
-    mr = MultiResult(mv, {"foo.bar": (1, 2, "c"), "foo.bar2": (3, 4, "f"),},)
+    mr = MultiResult(mv, {"foo.bar": (1, 2, "c"), "foo.bar2": (3, 4, "f")})
 
     with pytest.raises(ValueError, match="length mismatch"):
         MultiResult(
-            mv, {"foo.bar": (1, 2, 3), "foo.bar2": (1, 2, 3, 4),},
+            mv, {"foo.bar": (1, 2, 3), "foo.bar2": (1, 2, 3, 4)},
         )
 
     with pytest.raises(ValueError, match="length mismatch"):
         MultiResult(
-            mv, {"foo.tuple": (1,), "foo.scalar": 1,},
+            mv, {"foo.tuple": (1,), "foo.scalar": 1},
         )
 
 
@@ -113,7 +113,7 @@ def test_unnormalizable(default_plugin_resolver):
 def test_compute(default_plugin_resolver):
     dpr = default_plugin_resolver
     mv = MultiVerify(dpr)
-    mr = MultiResult(mv, {"testing.foo": 1, "testing.bar": 2,},)
+    mr = MultiResult(mv, {"testing.foo": 1, "testing.bar": 2})
 
     with pytest.raises(
         TypeError, match='"algo" must be of type `str` or `Dispatcher`, not'

--- a/metagraph/tests/test_multiverify.py
+++ b/metagraph/tests/test_multiverify.py
@@ -18,13 +18,17 @@ from metagraph.plugins.python.types import PythonNodeMapType
 
 def test_multiresult_consistent_length(default_plugin_resolver):
     mv = MultiVerify(default_plugin_resolver)
-    mr = MultiResult(mv, {"foo.bar": (1, 2, "c"), "foo.bar2": (3, 4, "f"),})
+    mr = MultiResult(mv, {"foo.bar": (1, 2, "c"), "foo.bar2": (3, 4, "f"),},)
 
     with pytest.raises(ValueError, match="length mismatch"):
-        MultiResult(mv, {"foo.bar": (1, 2, 3), "foo.bar2": (1, 2, 3, 4),})
+        MultiResult(
+            mv, {"foo.bar": (1, 2, 3), "foo.bar2": (1, 2, 3, 4),},
+        )
 
     with pytest.raises(ValueError, match="length mismatch"):
-        MultiResult(mv, {"foo.tuple": (1,), "foo.scalar": 1,})
+        MultiResult(
+            mv, {"foo.tuple": (1,), "foo.scalar": 1,},
+        )
 
 
 def test_multiresult_getitem(default_plugin_resolver):
@@ -109,7 +113,7 @@ def test_unnormalizable(default_plugin_resolver):
 def test_compute(default_plugin_resolver):
     dpr = default_plugin_resolver
     mv = MultiVerify(dpr)
-    mr = MultiResult(mv, {"testing.foo": 1, "testing.bar": 2,})
+    mr = MultiResult(mv, {"testing.foo": 1, "testing.bar": 2,},)
 
     with pytest.raises(
         TypeError, match='"algo" must be of type `str` or `Dispatcher`, not'

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,1 +1,1 @@
-$PYTHON setup.py install
+${PYTHON} setup.py install --single-version-externally-managed --record=record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,59 +1,43 @@
-# conda build -c conda-forge --python 3.7 recipe/
-
 package:
-  name: metagraph
-  version: {{ GIT_DESCRIBE_TAG }}
+   name: metagraph
+   version: {{ environ.get('GIT_DESCRIBE_TAG', 'unknown') }}
 
 source:
-  path: ..
+   path: ..
 
 build:
-  number: {{ GIT_DESCRIBE_NUMBER|int }}
-  string: py{{ PY_VER }}h{{ PKG_HASH }}_{{GIT_DESCRIBE_HASH}}_{{ GIT_DESCRIBE_NUMBER }}
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0)|int }}
+  string: {{GIT_DESCRIBE_HASH}}_{{ GIT_DESCRIBE_NUMBER }}
+  noarch: python
 
 requirements:
-  host:
-    - python
-    - setuptools
-    - importlib_metadata
-    - numpy
-    - scipy
-    - donfig
-
+  build:
+    - python >=3.7
   run:
-    - python
-    - setuptools
+    - python >=3.7
     - importlib_metadata
-    - numpy
+    - numpy >=1.15
+    - networkx
+    - pandas
+    - python-louvain
     - scipy
     - donfig
+    - grblas >=1.3.2
     - dask
-    - websockets
+    - python-graphviz
+    - nest-asyncio
 
 test:
   requires:
     - pytest
-    - numpy
-    - scipy
-    - networkx
-    - grblas
-    - pandas
-    - python-louvain
-#    - pytest-cov
-#    - coverage
-#    - black
-
+    - pytest-cov
+    - coverage
+    - black >=20.8b1
   commands:
-    - pytest --pyargs metagraph.tests
+    - py.test --cov-report term-missing --cov=metagraph --pyargs metagraph.tests
 
 about:
-  home: https://github.com/ContinuumIO/metagraph
-  license: Apache 2.0
-  license_family: Apache
+  home: https://github.com/metagraph-dev/metagraph
+  license: Apache2
   license_file: LICENSE
-  summary: 'Graph algorithm solver across multiple hardware backends'
-  description: |
-    Python library for running graph algorithms on a variety of hardware backends.
-    Data representing the graph will be automatically converted between available hardware options
-    to find an efficient solution.
-  dev_url: https://github.com/ContinuumIO/metagraph
+  summary: Run graph algorithms on many backends


### PR DESCRIPTION
- Add test for util.graph.degree with undirected graphs
- Add pagerank call which forces reaching `maxiter`
- Fix networkx bugs associated with the above new tests
- Update pandas index set logic to avoid `&`, `|`, `^` in favor of the much more verbose `.intersection`, `.union`, `.symmetric_difference` which apparently make more sense to the developers such that they deprecated the use of the former