### PR TITLE
Raise TypeError when concrete types are used in abstract type signature

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -18,7 +18,7 @@ Installing using conda
 
 ::
 
-    conda install -c metagraph metagraph
+    conda install -c conda-forge -c metagraph metagraph
 
 
 Installing from PyPI

--- a/docs/getting_started/tutorial.ipynb
+++ b/docs/getting_started/tutorial.ipynb
@@ -31,7 +31,10 @@
    "source": [
     "## Inspecting Types and Available Algorithms\n",
     "\n",
-    "The default resolver automatically pulls in all registered Metagraph plugins."
+    "The default resolver automatically pulls in all registered Metagraph plugins.\n",
+    "\n",
+    "The default resolver also links itself with the `metagraph` namespace, allowing\n",
+    "users to ignore the default resolver in most cases."
    ]
   },
   {
@@ -61,6 +64,36 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Alternatively, simply access the types directly from `mg`.\n",
+    "\n",
+    "Most attributes of `res` are exposed as attributes on `mg` for convenience."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dir(mg.types)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "Two important concepts in Metagraph are abstract types and concrete types. \n",
@@ -84,14 +117,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dir(res.types.Graph)"
+    "dir(mg.types.Graph)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Algorithms are also listed under `res.algos` and grouped by categories."
+    "Available algorithms are listed under `mg.algos` and grouped by categories.\n",
+    "\n",
+    "Note that these are also available under `res.algos`."
    ]
   },
   {
@@ -100,7 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dir(res.algos)"
+    "dir(mg.algos)"
    ]
   },
   {
@@ -109,7 +144,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dir(res.algos.traversal)"
+    "dir(mg.algos.traversal)"
    ]
   },
   {
@@ -180,7 +215,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "em = res.wrappers.EdgeMap.PandasEdgeMap(df, 'Source', 'Destination', 'Weight', is_directed=False)\n",
+    "em = mg.wrappers.EdgeMap.PandasEdgeMap(df, 'Source', 'Destination', 'Weight', is_directed=False)\n",
     "em.value"
    ]
   },
@@ -201,7 +236,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = res.algos.util.graph.build(em)\n",
+    "g = mg.algos.util.graph.build(em)\n",
     "g"
    ]
   },
@@ -231,7 +266,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g2 = res.translate(g, res.wrappers.Graph.ScipyGraph)\n",
+    "g2 = mg.translate(g, mg.wrappers.Graph.ScipyGraph)\n",
     "g2"
    ]
   },
@@ -266,7 +301,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g3 = res.translate(g, res.types.Graph.GrblasGraphType)\n",
+    "g3 = mg.translate(g, mg.types.Graph.GrblasGraphType)\n",
     "g3"
    ]
   },
@@ -311,7 +346,7 @@
     "\n",
     "Rather than actually converting `g` into other formats, let’s ask Metagraph how it will do the conversion. Each conversion requires a translator (written by plugin developers) to convert between the two formats. However, even if there isn’t a direct translator between two formats, Metagraph will find a path and take several translation steps as needed to perform the task.\n",
     "\n",
-    "The mechanism for viewing the plan is to invoke the translation from ``res.plan.translate`` rather than ``res.translate``. Other than the additional ``.plan``, the call signature is identical.\n",
+    "The mechanism for viewing the plan is to invoke the translation from ``mg.plan.translate`` rather than ``mg.translate``. Other than the additional ``.plan``, the call signature is identical.\n",
     "\n",
     "In this first example, there is a direct function which translates between `NetworkXGraphType` and `ScipyGraphType`."
    ]
@@ -322,7 +357,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.plan.translate(g, res.types.Graph.ScipyGraphType)"
+    "mg.plan.translate(g, mg.types.Graph.ScipyGraphType)"
    ]
   },
   {
@@ -341,7 +376,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.plan.translate(g, res.types.Graph.GrblasGraphType)"
+    "mg.plan.translate(g, mg.types.Graph.GrblasGraphType)"
    ]
   },
   {
@@ -363,7 +398,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.algos.traversal.bfs_iter.signatures"
+    "mg.algos.traversal.bfs_iter.signatures"
    ]
   },
   {
@@ -382,7 +417,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cc = res.algos.traversal.bfs_iter(g, 0)\n",
+    "cc = mg.algos.traversal.bfs_iter(g, 0)\n",
     "cc"
    ]
   },
@@ -392,7 +427,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cc2 = res.algos.traversal.bfs_iter(g2, 0)\n",
+    "cc2 = mg.algos.traversal.bfs_iter(g2, 0)\n",
     "cc2"
    ]
   },
@@ -412,7 +447,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.plan.algos.traversal.bfs_iter(g, 0)"
+    "mg.plan.algos.traversal.bfs_iter(g, 0)"
    ]
   },
   {
@@ -429,7 +464,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.plan.algos.traversal.bfs_iter(g2, 0)"
+    "mg.plan.algos.traversal.bfs_iter(g2, 0)"
    ]
   },
   {
@@ -451,7 +486,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.algos.centrality.pagerank.signatures"
+    "mg.algos.centrality.pagerank.signatures"
    ]
   },
   {
@@ -470,7 +505,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "res.plan.algos.centrality.pagerank(g2)"
+    "mg.plan.algos.centrality.pagerank(g2)"
    ]
   },
   {
@@ -479,7 +514,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pr = res.algos.centrality.pagerank(g2)\n",
+    "pr = mg.algos.centrality.pagerank(g2)\n",
     "pr"
    ]
   },
@@ -512,8 +547,36 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pr_array = res.translate(pr, res.types.NodeMap.NumpyNodeMapType)\n",
+    "pr_array = mg.translate(pr, mg.types.NodeMap.NumpyNodeMapType)\n",
     "pr_array.value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Helpful tip**: The translation type can also be specified as a string"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "mg.translate(pr, \"NumpyNodeMap\")"
    ]
   },
   {
@@ -533,7 +596,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pr2 = res.algos.centrality.pagerank(g)\n",
+    "pr2 = mg.algos.centrality.pagerank(g)\n",
     "pr2"
    ]
   },
@@ -550,7 +613,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pr2_array = res.translate(pr2, res.types.NodeMap.NumpyNodeMapType)\n",
+    "pr2_array = mg.translate(pr2, \"NumpyNodeMap\")\n",
     "pr2_array.value"
    ]
   },

--- a/docs/getting_started/use_case_1_airline_connectedness.ipynb
+++ b/docs/getting_started/use_case_1_airline_connectedness.ipynb
@@ -706,13 +706,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "r = mg.resolver\n",
-    "passenger_flow_edge_map = r.wrappers.EdgeMap.PandasEdgeMap(passenger_flow_df, \n",
+    "passenger_flow_edge_map = mg.wrappers.EdgeMap.PandasEdgeMap(passenger_flow_df,\n",
     "                                                           'ORIGIN_CITY_MARKET_ID', \n",
     "                                                           'DEST_CITY_MARKET_ID', \n",
     "                                                           'INVERSE_PASSENGER_COUNT',\n",
     "                                                           is_directed=True)\n",
-    "passenger_flow_graph = r.algos.util.graph.build(passenger_flow_edge_map)"
+    "passenger_flow_graph = mg.algos.util.graph.build(passenger_flow_edge_map)"
    ]
   },
   {
@@ -730,7 +729,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "betweenness_centrality = r.algos.centrality.betweenness(passenger_flow_graph, normalize=False)"
+    "betweenness_centrality = mg.algos.centrality.betweenness(passenger_flow_graph, normalize=False)"
    ]
   },
   {
@@ -758,9 +757,9 @@
    ],
    "source": [
     "number_of_best_scores = 15\n",
-    "best_betweenness_centrality_node_vector = r.algos.util.nodemap.sort(betweenness_centrality, ascending=False, limit=number_of_best_scores)\n",
-    "best_betweenness_centrality_node_set = r.algos.util.nodeset.from_vector(best_betweenness_centrality_node_vector)\n",
-    "best_betweenness_centrality_node_to_score_map = r.algos.util.nodemap.select(betweenness_centrality, best_betweenness_centrality_node_set)\n",
+    "best_betweenness_centrality_node_vector = mg.algos.util.nodemap.sort(betweenness_centrality, ascending=False, limit=number_of_best_scores)\n",
+    "best_betweenness_centrality_node_set = mg.algos.util.nodeset.from_vector(best_betweenness_centrality_node_vector)\n",
+    "best_betweenness_centrality_node_to_score_map = mg.algos.util.nodemap.select(betweenness_centrality, best_betweenness_centrality_node_set)\n",
     "best_betweenness_centrality_node_to_score_map"
    ]
   },
@@ -802,7 +801,7 @@
     }
    ],
    "source": [
-    "best_betweenness_centrality_node_to_score_map = r.translate(best_betweenness_centrality_node_to_score_map, r.types.NodeMap.PythonNodeMapType)\n",
+    "best_betweenness_centrality_node_to_score_map = mg.translate(best_betweenness_centrality_node_to_score_map, mg.types.NodeMap.PythonNodeMapType)\n",
     "best_betweenness_centrality_node_to_score_map"
    ]
   },

--- a/docs/getting_started/use_case_2_netflix_kevin_bacon.ipynb
+++ b/docs/getting_started/use_case_2_netflix_kevin_bacon.ipynb
@@ -795,8 +795,7 @@
     "actor_ids = list(actor_to_id.values())\n",
     "movie_ids = list(movie_to_id.values())\n",
     "\n",
-    "r = mg.resolver\n",
-    "actor_id_to_movie_id_graph = r.wrappers.BipartiteGraph.NetworkXBipartiteGraph(nx_actor_to_movie_graph, [actor_ids, movie_ids])"
+    "actor_id_to_movie_id_graph = mg.wrappers.BipartiteGraph.NetworkXBipartiteGraph(nx_actor_to_movie_graph, [actor_ids, movie_ids])"
    ]
   },
   {
@@ -813,14 +812,14 @@
    "outputs": [],
    "source": [
     "actor_partition_label = 0\n",
-    "actor_id_to_actor_id_graph = r.algos.bipartite.graph_projection(actor_id_to_movie_id_graph, actor_partition_label)"
+    "actor_id_to_actor_id_graph = mg.algos.bipartite.graph_projection(actor_id_to_movie_id_graph, actor_partition_label)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The actor partition label is 0 because the actors are the 0th element of `[actor_ids, movie_ids]` that was passed into the bipartite graph initializer, i.e. `r.wrappers.BipartiteGraph.NetworkXBipartiteGraph`."
+    "The actor partition label is 0 because the actors are the 0th element of `[actor_ids, movie_ids]` that was passed into the bipartite graph initializer, i.e. `mg.wrappers.BipartiteGraph.NetworkXBipartiteGraph`."
    ]
   },
   {
@@ -941,7 +940,7 @@
     "    label_counts[label] += 1\n",
     "largest_cc_label, _ = max(label_counts.items(), key = lambda pair: pair[1])\n",
     "largest_cc_node_set = {node for node, label in cc_node_label_mapping.items() if label == largest_cc_label}\n",
-    "largest_cc_subgraph = r.algos.subgraph.extract_subgraph(actor_id_to_actor_id_graph, largest_cc_node_set)"
+    "largest_cc_subgraph = mg.algos.subgraph.extract_subgraph(actor_id_to_actor_id_graph, largest_cc_node_set)"
    ]
   },
   {
@@ -986,7 +985,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "largest_cc_subgraph = r.translate(largest_cc_subgraph, r.wrappers.Graph.ScipyGraph)"
+    "largest_cc_subgraph = largest_cc_subgraph.translate(\"ScipyGraph\")"
    ]
   },
   {
@@ -1002,8 +1001,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "largest_cc_subgraph = r.algos.util.graph.assign_uniform_weight(largest_cc_subgraph, 1.0)\n",
-    "_, lengths_graph = r.algos.traversal.all_pairs_shortest_paths(largest_cc_subgraph)"
+    "largest_cc_subgraph = mg.algos.util.graph.assign_uniform_weight(largest_cc_subgraph, 1.0)\n",
+    "_, lengths_graph = mg.algos.traversal.all_pairs_shortest_paths(largest_cc_subgraph)"
    ]
   },
   {
@@ -1019,7 +1018,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "actor_id_to_kevin_bacon_distance = r.algos.util.graph.aggregate_edges(lengths_graph, np.maximum, 0, True, True)"
+    "actor_id_to_kevin_bacon_distance = mg.algos.util.graph.aggregate_edges(lengths_graph, np.maximum, 0, True, True)"
    ]
   },
   {
@@ -1046,7 +1045,7 @@
     }
    ],
    "source": [
-    "min_kevin_bacon_dist = r.algos.util.nodemap.reduce(actor_id_to_kevin_bacon_distance, np.minimum)\n",
+    "min_kevin_bacon_dist = mg.algos.util.nodemap.reduce(actor_id_to_kevin_bacon_distance, np.minimum)\n",
     "min_kevin_bacon_dist"
    ]
   },
@@ -1085,7 +1084,7 @@
     }
    ],
    "source": [
-    "kevin_bacon_ids = r.algos.util.nodemap.filter(actor_id_to_kevin_bacon_distance, lambda distance: distance == min_kevin_bacon_dist)\n",
+    "kevin_bacon_ids = mg.algos.util.nodemap.filter(actor_id_to_kevin_bacon_distance, lambda distance: distance == min_kevin_bacon_dist)\n",
     "kevin_bacons = [actor_id_to_actor[actor_id] for actor_id in kevin_bacon_ids.value]\n",
     "kevin_bacons[:10]"
    ]

--- a/docs/getting_started/use_case_3_ecommerce_customer_interests.ipynb
+++ b/docs/getting_started/use_case_3_ecommerce_customer_interests.ipynb
@@ -572,15 +572,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "r = mg.resolver"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -838,7 +829,7 @@
     "\n",
     "nx_bipartite_graph = nx.Graph()\n",
     "nx_bipartite_graph.add_edges_from(edges)\n",
-    "bipartite_graph = r.wrappers.BipartiteGraph.NetworkXBipartiteGraph(\n",
+    "bipartite_graph = mg.wrappers.BipartiteGraph.NetworkXBipartiteGraph(\n",
     "    nx_bipartite_graph, \n",
     "    [customer_id_node_ids, stock_code_node_ids]\n",
     ")"
@@ -857,7 +848,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "customer_similarity_graph = r.algos.bipartite.graph_projection(bipartite_graph, 0)"
+    "customer_similarity_graph = mg.algos.bipartite.graph_projection(bipartite_graph, 0)"
    ]
   },
   {
@@ -873,7 +864,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "customer_similarity_graph = r.algos.util.graph.assign_uniform_weight(\n",
+    "customer_similarity_graph = mg.algos.util.graph.assign_uniform_weight(\n",
     "    customer_similarity_graph, \n",
     "    1.0\n",
     ")"
@@ -892,7 +883,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "community_labels, modularity_score = r.algos.clustering.louvain_community(\n",
+    "community_labels, modularity_score = mg.algos.clustering.louvain_community(\n",
     "    customer_similarity_graph\n",
     ")"
    ]

--- a/docs/plugin_author_guide/plugin_parts.rst
+++ b/docs/plugin_author_guide/plugin_parts.rst
@@ -44,7 +44,7 @@ Here's some example code showing how to declare an abstract algorithm:
  .. code-block:: python
 
      from metagraph import abstract_algorithm
-     from metagraph.types import Graph
+     from metagraph.plugins.core.types import Graph
 
      @abstract_algorithm("centrality.pagerank")
      def pagerank(
@@ -204,22 +204,34 @@ Since wrappers automatically introduce concrete types, wrappers are also useful 
 
     class NetworkXEdgeMap(EdgeMapWrapper, abstract=EdgeMap):
         def __init__(
-            self, nx_graph, weight_label="weight",
+            self, nx_graph, weight_label="weight", *, aprops=None
         ):
+            super().__init__(aprops=aprops)
             self.value = nx_graph
             self.weight_label = weight_label
             self._assert_instance(nx_graph, nx.Graph)
 
-        @classmethod
-        def assert_equal(cls, obj1, obj2, props1, props2, *, rel_tol=1e-9, abs_tol=0.0):
-            ...
-            return
+        class TypeMixin:
+            @classmethod
+            def _compute_abstract_properties(
+                cls, obj, props: Set[str], known_props: Dict[str, Any]
+            ) -> Dict[str, Any]:
+                ...
+                return
+
+            @classmethod
+            def assert_equal(cls, obj1, obj2, aprops1, aprops2, cprops1, cprops2,
+                             *, rel_tol=1e-9, abs_tol=0.0):
+                ...
+                return
 
 It's conventional to have the underlying data stored in the ``value`` attribute.
 
-It's highly recommended to use the inherited ``_assert_instance`` wrapper method to sanity check types. 
+If the underlying abstract type has abstract properties, it is required to define ``_compute_abstract_properties``.
 
-It's highly recommended to add an ``assert_equal`` class method as it gets inherited by the automatically created
+It is recommended to use the inherited ``_assert_instance`` wrapper method to sanity check types.
+
+It can be beneficial to add an ``assert_equal`` class method as it gets inherited by the automatically created
 concrete type and is useful for :ref:`testing purposes<testing_algorithms>`.
 
 For more about wrappers, see :ref:`here<wrappers>`.

--- a/docs/user_guide/dask.rst
+++ b/docs/user_guide/dask.rst
@@ -85,6 +85,9 @@ but it hasn't been computed yet. To do that, call ``.compute()`` on the object.
 
     {0: 5, 1: 4, 2: 3, 3: 2, 4: 1}
 
+There is also a way to :ref:`make the Dask resolver the default resolver<replacing_default_resolver>`.
+This would allow a call to ``mg.translate()`` to delegate to the Dask resolver instead of the default.
+
 
 Custom Dask Resolvers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user_guide/resolver.rst
+++ b/docs/user_guide/resolver.rst
@@ -22,14 +22,17 @@ where ``r`` is the resolver, ``x`` is the input object, and ``OutputConcType`` i
 describes the output object.
 
 Because there is typically a 1-to-1 relationship between an object and a concrete type,
-``OutputConcType`` is also allowed to be the class of the output object.
+``OutputConcType`` is also allowed to be the class of the output object. The system can also
+figure out the type from a string name (capitalization matters).
 
-For example, both of these statements are correct and will yield identical results.
+All of the following statements are correct and will yield identical results.
 
 .. code-block:: python
 
     r.translate(x, r.types.Graph.NetworkXGraphType)
     r.translate(x, r.wrappers.Graph.NetworkXGraph)
+    r.translate(x, "NetworkXGraphType")
+    r.translate(x, "NetworkXGraph")
 
 
 The path that is taken to get from the input object to the desired output may take several
@@ -174,9 +177,36 @@ Because of this, the default resolver should be accessed prior to any time-sensi
     import metagraph as mg
     r = mg.resolver
 
-Usually, the default resolver is sufficient for most scripts using metagraph. However, it is
+Hidden Default Resolver
+~~~~~~~~~~~~~~~~~~~~~~~
+Because the default resolver is used for almost every action in Metagraph, the default resolver
+is integrated seamlessly back into the ``metagraph`` namespace.
+
+The following are identical:
+
+.. code-block:: python
+
+    # Assumes `mg` and `r` from above
+    r.translate(x, "NetworkXGraph")
+    mg.translate(x, "NetworkXGraph")
+
+The full list of default resolver attributes copied into the ``metagraph`` namespace are:
+
+ - types
+ - wrappers
+ - algos
+ - translate
+ - run
+ - type_of
+ - typeclass_of
+ - plan
+
+Custom Resolver
+~~~~~~~~~~~~~~~
+
+The default resolver is usually sufficient for most scripts use cases of metagraph. However, it is
 also possible to create custom resolvers separate from the default resolver. This requires
-creating a Resolver and registering plugins manually.
+creating a ``Resolver`` and registering plugins manually.
 
 .. code-block:: python
 
@@ -187,3 +217,41 @@ For more information about registry format, see the :ref:`plugin_author_guide`.
 
 The only benefit of using a custom resolver rather than the default one is to limit concrete algorithms
 and translations which will be considered when resolving translation and algorithm calls.
+
+.. _replacing_default_resolver:
+
+Replacing the Default Resolver
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Replacing the default resolver is possible, both temporarily and permanently.
+
+To temporarily make a resolver the default:
+
+.. code-block:: python
+
+    some_resolver = ...
+    with some_resolver:
+        mg.translate(...)  # this now uses some_resolver
+
+    mg.translate(...)  # uses the original default resolver again
+
+To permanently replace the default resolver:
+
+.. code-block:: python
+
+    some_resolver = ...
+    some_resolver.set_as_default()
+
+    mg.translate(...)  # uses some_resolver
+
+    # To return to the original default
+    some_resolver.reset_default()
+
+    mg.translate(...)  # back to the original default resolver
+
+Of course, calling methods directly from the alternate resolver is also allowed and will work as expected.
+
+.. code-block:: python
+
+    some_resolver = ...
+    some_resolver.translate(...)

--- a/docs/user_guide/translators.rst
+++ b/docs/user_guide/translators.rst
@@ -24,7 +24,7 @@ output type.
 .. code-block:: python
 
     g = NetworkXGraph(...)
-    g2 = resolver.translate(g, CuGraph)
+    g2 = mg.translate(g, CuGraph)
 
 The primary rule of translators is that translation can only happen
 between objects of the same abstract type. There are exceptions to this rule,

--- a/docs/user_guide/types.rst
+++ b/docs/user_guide/types.rst
@@ -123,7 +123,7 @@ This inner class is created exactly like ``ConcreteType`` except for the followi
 - It does not define the abstract class (that is done in the Wrapper definition)
 - It does not define ``value_type``
 
-All other parts of ``ConcreteType`` *are* defined within the inner ``TypeMixin`` class:
+All other parts of ``ConcreteType`` are defined within the inner ``TypeMixin`` class:
 
 - allowed_props
 - _compute_abstract_properties
@@ -134,3 +134,20 @@ All other parts of ``ConcreteType`` *are* defined within the inner ``TypeMixin``
 When the wrapper is registered with Metagraph, this ``TypeMixin`` class will be converted into
 a proper ``ConcreteType`` and set as the ``.Type`` attribute on the wrapper. The ``value_type``
 will point to the wrapper class, linking the two objects.
+
+Wrapper Convenience Methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Several common resolver methods are made available as shortcuts on wrappers.
+
+- ``.translate(dst)`` will translate to another type
+- ``.run(algo_name, *args, **kwargs)`` will run an algorithm using the wrapper as the first argument
+
+This example shows equivalent calls:
+
+.. code-block:: python
+
+    y = mg.translate(x, "NetworkXGraph")
+    y = x.translate("NetworkXGraph")
+
+    pr = mg.algos.centrality.pagerank(x, damping=0.75)
+    pr = x.run("centrality.pagerank", damping=0.75)

--- a/metagraph/__init__.py
+++ b/metagraph/__init__.py
@@ -47,6 +47,7 @@ _SPECIAL_ATTRS = [
     "run",
     "type_of",
     "typeclass_of",
+    "plan",
 ]
 
 

--- a/metagraph/core/exceptions.py
+++ b/metagraph/core/exceptions.py
@@ -1,0 +1,2 @@
+class MetagraphError(Exception):
+    pass

--- a/metagraph/core/resolver.py
+++ b/metagraph/core/resolver.py
@@ -999,7 +999,9 @@ class _ResolverRegistrar:
             if issubclass(obj, AbstractType):
                 sig_mod.update_annotation(obj(), name=name, index=index)
                 return
-            # Non-abstract type class is assumed to be Python type
+            elif issubclass(obj, ConcreteType):
+                raise TypeError(f"{msg} may not have Concrete types in signature")
+            # Non-abstract and non-concrete type class is assumed to be Python type
             return
         elif isinstance(obj, mgtyping.Combo):
             if obj.kind not in {"python", "abstract", "node_id", "uniform_iterable"}:

--- a/metagraph/core/resolver.py
+++ b/metagraph/core/resolver.py
@@ -1008,6 +1008,8 @@ class _ResolverRegistrar:
                 raise TypeError(f"{msg} may not have Concrete types in Union")
             return
         elif isinstance(obj, mgtyping.UniformIterable):
+            if issubclass(type(obj.element_type), ConcreteType):
+                raise TypeError(f"{msg} may not have Concrete types in signature")
             return
         elif isinstance(obj, AbstractType):
             return

--- a/metagraph/core/resolver.py
+++ b/metagraph/core/resolver.py
@@ -273,6 +273,10 @@ class Resolver:
         if not isinstance(name, str):
             raise TypeError(f"name must be str, not {type(name)}")
 
+        # Interpret "FooBar.Type" instead of "FooBarType"
+        if "." in name and name.endswith(".Type"):
+            name = f"{name[:-5]}Type"
+
         # Check direct concrete types
         cat = getattr(self.types, starting_type.__name__)
         for ct in dir(cat):

--- a/metagraph/plugins/core/__init__.py
+++ b/metagraph/plugins/core/__init__.py
@@ -1,1 +1,1 @@
-from . import types, wrappers, algorithms
+from . import types, wrappers, algorithms, exceptions

--- a/metagraph/plugins/core/algorithms/centrality.py
+++ b/metagraph/plugins/core/algorithms/centrality.py
@@ -31,6 +31,9 @@ def pagerank(
     maxiter: int = 50,
     tolerance: float = 1e-05,
 ) -> NodeMap:
+    """
+    Must raise mg.plugins.core.exceptions.ConvergenceLimit if maxiter is reached
+    """
     pass  # pragma: no cover
 
 

--- a/metagraph/plugins/core/exceptions.py
+++ b/metagraph/plugins/core/exceptions.py
@@ -1,0 +1,14 @@
+from metagraph.core.exceptions import MetagraphError
+
+
+class MetagraphPluginError(MetagraphError):
+    pass
+
+
+class ConvergenceError(MetagraphPluginError):
+    """
+    Indicates an iterative algorithm failed to converge within the
+    required convergence limit.
+    """
+
+    pass

--- a/metagraph/plugins/graphblas/algorithms.py
+++ b/metagraph/plugins/graphblas/algorithms.py
@@ -1,5 +1,6 @@
 from metagraph import concrete_algorithm, NodeID
 from metagraph.plugins import has_grblas
+from metagraph.plugins.core import exceptions
 from typing import Tuple, Iterable, Any, Union, Optional
 import numpy as np
 
@@ -64,6 +65,10 @@ if has_grblas:
             err = prev_r.reduce().value
             if err < N * tolerance:
                 break
+        else:
+            raise exceptions.ConvergenceError(
+                f"failed to converge within {maxiter} iterations"
+            )
         return GrblasNodeMap(r)
 
     @concrete_algorithm("util.graph.build")

--- a/metagraph/tests/algorithms/test_centrality.py
+++ b/metagraph/tests/algorithms/test_centrality.py
@@ -4,6 +4,7 @@ import networkx as nx
 import numpy as np
 from . import MultiVerify
 from metagraph.plugins.networkx.types import NetworkXGraph
+from metagraph.plugins.core.exceptions import ConvergenceError
 
 
 def build_standard_graph(directed=True):
@@ -170,10 +171,10 @@ def test_pagerank_centrality(default_plugin_resolver):
         dpr.algos.centrality.pagerank, graph, tolerance=1e-7
     ).assert_equal(expected_val, rel_tol=1e-5)
 
-    # Test that hitting maxiter doesn't raise error
-    MultiVerify(dpr).compute(
+    # Test that hitting maxiter raises error
+    MultiVerify(dpr).compute_raises(
         dpr.algos.centrality.pagerank, graph, tolerance=1e-9, maxiter=2
-    )
+    ).assert_raises(ConvergenceError)
 
 
 def test_closeness_centrality(default_plugin_resolver):

--- a/metagraph/tests/test_resolver.py
+++ b/metagraph/tests/test_resolver.py
@@ -256,23 +256,44 @@ def test_register_errors():
         res.register(registry.plugins)
 
     # Don't allow concrete types in abstract algorithm signature
+
     @abstract_algorithm("testing.abst_algo_bad_return_type")
-    def abst_algo_bad_return_type(x: int) -> Concrete1:  # pragma: no cover
+    def abst_algo_bad_return_type_1(x: int) -> Concrete1:  # pragma: no cover
         pass
 
     with pytest.raises(TypeError, match=" may not have Concrete types in signature"):
         registry = PluginRegistry("test_register_errors_default_plugin")
-        registry.register(abst_algo_bad_return_type)
+        registry.register(abst_algo_bad_return_type_1)
         res_tmp = Resolver()
         res_tmp.register(registry.plugins)
 
     @abstract_algorithm("testing.abst_algo_bad_parameter_type")
-    def abst_algo_bad_parameter_type(x: Concrete1) -> int:  # pragma: no cover
+    def abst_algo_bad_parameter_type_1(x: Concrete1) -> int:  # pragma: no cover
         pass
 
     with pytest.raises(TypeError, match=" may not have Concrete types in signature"):
         registry = PluginRegistry("test_register_errors_default_plugin")
-        registry.register(abst_algo_bad_parameter_type)
+        registry.register(abst_algo_bad_parameter_type_1)
+        res_tmp = Resolver()
+        res_tmp.register(registry.plugins)
+
+    @abstract_algorithm("testing.abst_algo_bad_return_type")
+    def abst_algo_bad_return_type_2(x: int) -> List[Concrete1]:  # pragma: no cover
+        pass
+
+    with pytest.raises(TypeError, match=" may not have Concrete types in signature"):
+        registry = PluginRegistry("test_register_errors_default_plugin")
+        registry.register(abst_algo_bad_return_type_2)
+        res_tmp = Resolver()
+        res_tmp.register(registry.plugins)
+
+    @abstract_algorithm("testing.abst_algo_bad_parameter_type")
+    def abst_algo_bad_parameter_type_2(x: List[Concrete1]) -> int:  # pragma: no cover
+        pass
+
+    with pytest.raises(TypeError, match=" may not have Concrete types in signature"):
+        registry = PluginRegistry("test_register_errors_default_plugin")
+        registry.register(abst_algo_bad_parameter_type_2)
         res_tmp = Resolver()
         res_tmp.register(registry.plugins)
 

--- a/metagraph/tests/test_resolver.py
+++ b/metagraph/tests/test_resolver.py
@@ -255,6 +255,27 @@ def test_register_errors():
         registry.register(my_any, "my_any_plugin")
         res.register(registry.plugins)
 
+    # Don't allow concrete types in abstract algorithm signature
+    @abstract_algorithm("testing.abst_algo_bad_return_type")
+    def abst_algo_bad_return_type(x: int) -> Concrete1:  # pragma: no cover
+        pass
+
+    with pytest.raises(TypeError, match=" may not have Concrete types in signature"):
+        registry = PluginRegistry("test_register_errors_default_plugin")
+        registry.register(abst_algo_bad_return_type)
+        res_tmp = Resolver()
+        res_tmp.register(registry.plugins)
+
+    @abstract_algorithm("testing.abst_algo_bad_parameter_type")
+    def abst_algo_bad_parameter_type(x: Concrete1) -> int:  # pragma: no cover
+        pass
+
+    with pytest.raises(TypeError, match=" may not have Concrete types in signature"):
+        registry = PluginRegistry("test_register_errors_default_plugin")
+        registry.register(abst_algo_bad_parameter_type)
+        res_tmp = Resolver()
+        res_tmp.register(registry.plugins)
+
 
 def test_union_signatures():
     class Abstract1(AbstractType):

--- a/metagraph/tests/translators/test_node_map.py
+++ b/metagraph/tests/translators/test_node_map.py
@@ -59,6 +59,7 @@ def test_method_call(default_plugin_resolver):
         # string of ConcreteType class name
         dpr.assert_equal(x.translate("PythonNodeMapType"), y)
         dpr.assert_equal(x.translate("GrblasNodeMapType"), z)
+        dpr.assert_equal(x.translate("GrblasNodeMap.Type"), z)
 
 
 def test_method_call_secondary(default_plugin_resolver):


### PR DESCRIPTION
This PR is intended to address https://github.com/metagraph-dev/metagraph/issues/171. 

This commit makes it so that abstract algorithms with any of the following signatures raise `TypeError` exceptions:
- `def abst_algo(x: int) -> Concrete1:`
- `def abst_algo(x: Concrete1) -> int:`
- `def abst_algo(x: int) -> List[Concrete1]:`
- `def abst_algo(x: List[Concrete1]) -> int:`