### PR TITLE
Update MultiVerify to test for expected exceptions

### DIFF
--- a/metagraph/core/exceptions.py
+++ b/metagraph/core/exceptions.py
@@ -1,0 +1,2 @@
+class MetagraphError(Exception):
+    pass

--- a/metagraph/plugins/core/__init__.py
+++ b/metagraph/plugins/core/__init__.py
@@ -1,1 +1,1 @@
-from . import types, wrappers, algorithms
+from . import types, wrappers, algorithms, exceptions

--- a/metagraph/plugins/core/algorithms/centrality.py
+++ b/metagraph/plugins/core/algorithms/centrality.py
@@ -31,6 +31,9 @@ def pagerank(
     maxiter: int = 50,
     tolerance: float = 1e-05,
 ) -> NodeMap:
+    """
+    Must raise mg.plugins.core.exceptions.ConvergenceLimit if maxiter is reached
+    """
     pass  # pragma: no cover
 
 

--- a/metagraph/plugins/core/exceptions.py
+++ b/metagraph/plugins/core/exceptions.py
@@ -1,0 +1,14 @@
+from metagraph.core.exceptions import MetagraphError
+
+
+class MetagraphPluginError(MetagraphError):
+    pass
+
+
+class ConvergenceError(MetagraphPluginError):
+    """
+    Indicates an iterative algorithm failed to converge within the
+    required convergence limit.
+    """
+
+    pass

--- a/metagraph/plugins/graphblas/algorithms.py
+++ b/metagraph/plugins/graphblas/algorithms.py
@@ -1,5 +1,6 @@
 from metagraph import concrete_algorithm, NodeID
 from metagraph.plugins import has_grblas
+from metagraph.plugins.core import exceptions
 from typing import Tuple, Iterable, Any, Union, Optional
 import numpy as np
 
@@ -64,6 +65,10 @@ if has_grblas:
             err = prev_r.reduce().value
             if err < N * tolerance:
                 break
+        else:
+            raise exceptions.ConvergenceError(
+                f"failed to converge within {maxiter} iterations"
+            )
         return GrblasNodeMap(r)
 
     @concrete_algorithm("util.graph.build")

--- a/metagraph/tests/algorithms/test_centrality.py
+++ b/metagraph/tests/algorithms/test_centrality.py
@@ -4,6 +4,7 @@ import networkx as nx
 import numpy as np
 from . import MultiVerify
 from metagraph.plugins.networkx.types import NetworkXGraph
+from metagraph.plugins.core.exceptions import ConvergenceError
 
 
 def build_standard_graph(directed=True):
@@ -170,10 +171,10 @@ def test_pagerank_centrality(default_plugin_resolver):
         dpr.algos.centrality.pagerank, graph, tolerance=1e-7
     ).assert_equal(expected_val, rel_tol=1e-5)
 
-    # Test that hitting maxiter doesn't raise error
-    MultiVerify(dpr).compute(
+    # Test that hitting maxiter raises error
+    MultiVerify(dpr).compute_raises(
         dpr.algos.centrality.pagerank, graph, tolerance=1e-9, maxiter=2
-    )
+    ).assert_raises(ConvergenceError)
 
 
 def test_closeness_centrality(default_plugin_resolver):


### PR DESCRIPTION
MultiVerify now has `.compute_raises` method which will capture exceptions rather than raising.

Combined with a new `.assert_raises` method to test for exceptions, this allows the ability to test for expected exceptions in all concrete implementations.