### PR TITLE
Custom visualize() method

### DIFF
--- a/continuous_integration/environment.yml
+++ b/continuous_integration/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - pytest
   - pytest-cov
   - black
+  - python-graphviz
 
 # metagraph dependencies (so setup.py develop doesn't pip install them)
   - importlib_metadata

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - pytest-cov
   - black
   - conda-forge::pre-commit
+  - python-graphviz
 
 # documentation
   - sphinx=3.0.4

--- a/metagraph/core/dask/placeholder.py
+++ b/metagraph/core/dask/placeholder.py
@@ -6,6 +6,7 @@ from dask.core import quote, flatten
 from dask.highlevelgraph import HighLevelGraph
 from metagraph.core.plugin import ConcreteAlgorithm, ConcreteType
 from metagraph.core.compiler import optimize
+from .visualize import visualize
 from .tasks import DelayedAlgo
 
 
@@ -88,6 +89,15 @@ class Placeholder(DaskMethodsMixin):
     @staticmethod
     def __dask_optimize__(dsk, keys, **kwargs):
         return optimize(dsk, output_keys=list(flatten(keys)), **kwargs)
+
+    def visualize(self, filename="mydask", format=None, optimize_graph=False, **kwargs):
+        return visualize(
+            self,
+            filename=filename,
+            format=format,
+            optimize_graph=optimize_graph,
+            **kwargs,
+        )
 
     @classmethod
     def build(cls, key, func, args, kwargs=None, result_type=None, resolver=None):

--- a/metagraph/core/dask/resolver.py
+++ b/metagraph/core/dask/resolver.py
@@ -162,12 +162,17 @@ class DaskResolver:
                 f"{src_type.__name__}->{dst_type.__name__}",
             )
             kwargs = {}
-            # Pass in the real resolver if needed by the translator
-            if trans._include_resolver:
-                kwargs["resolver"] = self._resolver
             if dst_type is mst.final_type:
                 kwargs.update(props)
-            obj = ph.build(key, trans, (obj,), kwargs)
+            obj = ph.build(
+                key,
+                trans,
+                (obj,),
+                kwargs,
+                resolver=self._resolver,
+                source_type=src_type,
+                result_type=dst_type,
+            )
             src_type = dst_type
         return obj
 

--- a/metagraph/core/dask/tasks.py
+++ b/metagraph/core/dask/tasks.py
@@ -1,5 +1,5 @@
 from metagraph.core.plugin import ConcreteAlgorithm, ConcreteType, Translator
-from typing import Callable
+from typing import Callable, List
 
 
 class MetagraphTask:
@@ -38,6 +38,27 @@ class DelayedAlgo(MetagraphTask):
     @property
     def func_label(self):
         return f"{self.algo.abstract_name}\n({self.algo.__name__})"
+
+
+class DelayedJITAlgo(MetagraphTask):
+    def __init__(
+        self,
+        func: Callable,
+        compiler: str,
+        source_algos: List[ConcreteAlgorithm],
+        result_type: ConcreteType,
+        resolver: "Resolver",
+    ):
+        self.source_algos = source_algos
+        self.compiler = compiler
+        super().__init__(callable=func, result_type=result_type)
+
+    @property
+    def func_label(self):
+        label = f"{self.compiler} fused:\n"
+        for algo in self.source_algos:
+            label += f" {algo.__name__}\n"
+        return label
 
 
 class DelayedTranslate(MetagraphTask):

--- a/metagraph/core/dask/tasks.py
+++ b/metagraph/core/dask/tasks.py
@@ -1,18 +1,62 @@
-from metagraph.core.plugin import ConcreteAlgorithm, ConcreteType
+from metagraph.core.plugin import ConcreteAlgorithm, ConcreteType, Translator
+from typing import Callable
 
 
-class DelayedAlgo:
+class MetagraphTask:
+    def __init__(self, callable: Callable, result_type: ConcreteType):
+        self.callable = callable
+        self.result_type = result_type
+
+    def __call__(self, *args, **kwargs):
+        return self.callable(*args, **kwargs)
+
+    @property
+    def func_label(self):
+        return self.callable.__name__
+
+    @property
+    def data_label(self):
+        return self.result_type.__name__
+
+
+class DelayedAlgo(MetagraphTask):
     def __init__(
         self, algo: ConcreteAlgorithm, result_type: ConcreteType, resolver: "Resolver"
     ):
         self.algo = algo
         self.resolver = resolver
-        self.result_type = result_type
 
-    def __call__(self, args, kwargs):
-        algo = self.algo
-        if algo._include_resolver or algo._compiler:
-            # do not mutate the kwargs
-            kwargs = kwargs.copy()
-            kwargs["resolver"] = self.resolver
-        return self.algo(*args, **kwargs)
+        def call(args, kwargs):
+            if algo._include_resolver or algo._compiler:
+                # do not mutate the kwargs
+                kwargs = kwargs.copy()
+                kwargs["resolver"] = resolver
+            return algo(*args, **kwargs)
+
+        super().__init__(callable=call, result_type=result_type)
+
+    @property
+    def func_label(self):
+        return f"{self.algo.abstract_name}\n({self.algo.__name__})"
+
+
+class DelayedTranslate(MetagraphTask):
+    def __init__(
+        self, translator: Translator, source_type, result_type, resolver: "Resolver"
+    ):
+        self.translator = translator
+        self.resolver = resolver
+        self.source_type = source_type
+
+        def call(args, kwargs):
+            if translator._include_resolver:
+                # do not mutate the kwargs
+                kwargs = kwargs.copy()
+                kwargs["resolver"] = resolver
+            return translator(*args, **kwargs)
+
+        super().__init__(callable=call, result_type=result_type)
+
+    @property
+    def func_label(self):
+        return f"{self.source_type.__name__}->{self.result_type.__name__}\n({self.translator.__name__})"

--- a/metagraph/core/dask/visualize.py
+++ b/metagraph/core/dask/visualize.py
@@ -1,5 +1,5 @@
 import dask.base
-from .tasks import DelayedAlgo
+from .tasks import MetagraphTask, DelayedAlgo, DelayedTranslate
 from copy import deepcopy
 from typing import Dict, Hashable, Any
 from collections.abc import Mapping
@@ -46,15 +46,19 @@ def visualize(*dags, filename="mydask", format=None, optimize_graph=False, **kwa
     for key, task in merged_dag.items():
         task_callable = task[0]
 
-        if isinstance(task_callable, DelayedAlgo):
+        if isinstance(task_callable, MetagraphTask):
             func_attrs = {
-                "shape": "octagon",
-                "label": f"{task_callable.algo.abstract_name}\n({task_callable.algo.__name__})",
+                "label": task_callable.func_label,
             }
             data_attrs = {
                 "shape": "parallelogram",
-                "label": f"{task_callable.result_type.__class__.__name__}",
+                "label": task_callable.data_label,
             }
+
+            if isinstance(task_callable, DelayedAlgo):
+                func_attrs["shape"] = "octagon"
+            if isinstance(task_callable, DelayedTranslate):
+                func_attrs["shape"] = "ellipse"
         else:
             continue
 

--- a/metagraph/core/dask/visualize.py
+++ b/metagraph/core/dask/visualize.py
@@ -1,5 +1,5 @@
 import dask.base
-from .tasks import MetagraphTask, DelayedAlgo, DelayedTranslate
+from .tasks import MetagraphTask, DelayedAlgo, DelayedJITAlgo, DelayedTranslate
 from copy import deepcopy
 from typing import Dict, Hashable, Any
 from collections.abc import Mapping
@@ -57,8 +57,15 @@ def visualize(*dags, filename="mydask", format=None, optimize_graph=False, **kwa
 
             if isinstance(task_callable, DelayedAlgo):
                 func_attrs["shape"] = "octagon"
+                if task_callable.algo._compiler is not None:
+                    func_attrs["color"] = "red"
+                    func_attrs["penwidth"] = "2.0"
             if isinstance(task_callable, DelayedTranslate):
                 func_attrs["shape"] = "ellipse"
+            if isinstance(task_callable, DelayedJITAlgo):
+                func_attrs["shape"] = "doubleoctagon"
+                func_attrs["color"] = "red"
+                func_attrs["penwidth"] = "2.0"
         else:
             continue
 

--- a/metagraph/core/dask/visualize.py
+++ b/metagraph/core/dask/visualize.py
@@ -1,0 +1,79 @@
+import dask.base
+from .tasks import DelayedAlgo
+from copy import deepcopy
+from typing import Dict, Hashable, Any
+from collections.abc import Mapping
+
+
+def merge_dict_of_dict(
+    base: Dict[Hashable, Dict[Hashable, Any]],
+    overlay: Dict[Hashable, Dict[Hashable, Any]],
+):
+    """Returns a copy of base with keys and values from overlay merged on top."""
+    result = deepcopy(base)
+    for key, attrs in overlay.items():
+        if key not in result:
+            result[key] = attrs.copy()
+        else:
+            result[key].update(attrs)
+    return result
+
+
+def visualize(*dags, filename="mydask", format=None, optimize_graph=False, **kwargs):
+    """Custom visualization of DAGs with Metagraph nodes.
+
+    Arguments are the same as standard dask visualize method"""
+
+    # We customize the behavior of the visualization entirely through function
+    # and data attributes. Function attributes style the node corresponding to
+    # the task execution node whereas data attributes style the output result
+    # node associated with the task.  Result nodes can be hidded with the
+    # ``collapse_ouput`` option. Attribute key/value pairs can be anything
+    # that graphviz can handle.
+
+    # combine arguments into one large task list (cf. dask.base.visualize)
+    merged_dag = {}
+    for dag in dags:
+        if isinstance(dag, Mapping):
+            merged_dag.update(dag)
+        elif dask.base.is_dask_collection(dag):
+            merged_dag.update(dag.__dask_graph__())
+
+    # To give the caller priority to override styling, first compute
+    # attributes then overlay any attributes that were passed in.
+    function_attributes = {}
+    data_attributes = {}
+    for key, task in merged_dag.items():
+        task_callable = task[0]
+
+        if isinstance(task_callable, DelayedAlgo):
+            func_attrs = {
+                "shape": "octagon",
+                "label": f"{task_callable.algo.abstract_name}\n({task_callable.algo.__name__})",
+            }
+            data_attrs = {
+                "shape": "parallelogram",
+                "label": f"{task_callable.result_type.__class__.__name__}",
+            }
+        else:
+            continue
+
+        function_attributes[key] = func_attrs
+        data_attributes[key] = data_attrs
+
+    # overlay user-provided attributes
+    user_function_attributes = kwargs.pop("function_attributes", {})
+    user_data_attributes = kwargs.pop("data_attributes", {})
+
+    # let dask's visualize() do the heavy lifting
+    return dask.base.visualize(
+        merged_dag,
+        filename=filename,
+        format=format,
+        optimize_graph=optimize_graph,
+        function_attributes=merge_dict_of_dict(
+            function_attributes, user_function_attributes
+        ),
+        data_attributes=merge_dict_of_dict(data_attributes, user_data_attributes),
+        **kwargs,
+    )

--- a/metagraph/core/plugin.py
+++ b/metagraph/core/plugin.py
@@ -103,6 +103,7 @@ class ConcreteType:
                 raise KeyError(f"{key} not allowed property of {self.__class__}")
             # maybe type check?
         self.props = dict(props)
+        self.__name__ = self.__class__.__name__
 
     def __init_subclass__(cls, *, abstract=None):
         """Enforce requirements on 'abstract' attribute"""

--- a/metagraph/tests/compiler/test_compile.py
+++ b/metagraph/tests/compiler/test_compile.py
@@ -11,7 +11,7 @@ def test_compile_immediate(example_resolver):
     def add_two(x: int) -> int:  # pragma: no cover
         pass
 
-    @concrete_algorithm("testing.add_two", compiler="identity")
+    @concrete_algorithm("testing.add_two", compiler="identity_comp")
     def add_two_c(x: int) -> int:  # pragma: no cover
         return x + 2
 

--- a/metagraph/tests/compiler/test_subgraphs.py
+++ b/metagraph/tests/compiler/test_subgraphs.py
@@ -45,13 +45,13 @@ def test_extract_subgraphs_singleton(res):
 
     # default behavior is to include compilable single node subgraphs
     subgraphs = mg_compiler.extract_compilable_subgraphs(
-        z.__dask_graph__(), output_keys=[z.key], compiler="identity"
+        z.__dask_graph__(), output_keys=[z.key], compiler="identity_comp"
     )
     assert len(subgraphs) == 1
 
     # disable
     subgraphs = mg_compiler.extract_compilable_subgraphs(
-        z._dsk, compiler="identity", output_keys=[z.key], include_singletons=False
+        z._dsk, compiler="identity_comp", output_keys=[z.key], include_singletons=False
     )
     assert len(subgraphs) == 0
 
@@ -62,7 +62,7 @@ def test_extract_subgraphs_chain(res):
     z = scale_func(scale_func(scale_func(a, 2.0), 3.0), 4.0)
 
     subgraphs = mg_compiler.extract_compilable_subgraphs(
-        z.__dask_graph__(), output_keys=[z.key], compiler="identity"
+        z.__dask_graph__(), output_keys=[z.key], compiler="identity_comp"
     )
     assert len(subgraphs) == 1
     subgraph = subgraphs[0]
@@ -84,7 +84,7 @@ def test_extract_subgraphs_two_chains(res):
 
     subgraphs = mg_compiler.extract_compilable_subgraphs(
         merge.__dask_graph__(),
-        compiler="identity",
+        compiler="identity_comp",
         output_keys=[merge.key],
         include_singletons=False,  # exclude the add node
     )
@@ -100,7 +100,7 @@ def test_extract_subgraphs_two_chains(res):
     subgraphs = mg_compiler.extract_compilable_subgraphs(
         merge.__dask_graph__(),
         output_keys=[merge.key],
-        compiler="identity",
+        compiler="identity_comp",
         include_singletons=True,
     )
     assert len(subgraphs) == 3
@@ -120,7 +120,7 @@ def test_extract_subgraphs_three_chains(res):
     # but the merge node can start the final chain
 
     subgraphs = mg_compiler.extract_compilable_subgraphs(
-        ans.__dask_graph__(), output_keys=[ans.key], compiler="identity"
+        ans.__dask_graph__(), output_keys=[ans.key], compiler="identity_comp"
     )
     assert len(subgraphs) == 3
 
@@ -169,7 +169,7 @@ def test_extract_subgraphs_diamond(res):
     subgraphs = mg_compiler.extract_compilable_subgraphs(
         result_node.__dask_graph__(),
         output_keys=[result_node.key],
-        compiler="identity",
+        compiler="identity_comp",
     )
     assert len(subgraphs) == 4
 
@@ -192,7 +192,7 @@ def test_extract_subgraphs_diamond(res):
 
     subgraphs = mg_compiler.extract_compilable_subgraphs(
         result_node.__dask_graph__(),
-        compiler="identity",
+        compiler="identity_comp",
         output_keys=[result_node.key],
         include_singletons=False,
     )
@@ -208,7 +208,7 @@ def test_compile_subgraphs_three_chains(res):
     merge = res.algos.testing.add(z1, z2)
     ans = scale_func(merge, 2.8)
 
-    compiler = res.compilers["identity"]
+    compiler = res.compilers["identity_comp"]
 
     optimized_dsk = mg_compiler.compile_subgraphs(
         ans.__dask_graph__(), output_keys=[ans.key], compiler=compiler
@@ -231,7 +231,7 @@ def test_compile_subgraph_kwargs(res):
     offset_func = res.algos.testing.offset
     z = offset_func(offset_func(a=a, offset=1.0), offset=2.0)
 
-    compiler = res.compilers["identity"]
+    compiler = res.compilers["identity_comp"]
 
     optimized_dsk = mg_compiler.compile_subgraphs(
         z.__dask_graph__(), output_keys=[z.key], compiler=compiler
@@ -253,7 +253,7 @@ def test_extract_subgraphs_multiple_outputs(res):
     z = scale_func(y, 4.0)
 
     subgraphs = mg_compiler.extract_compilable_subgraphs(
-        z.__dask_graph__(), output_keys=[z.key, y.key], compiler="identity"
+        z.__dask_graph__(), output_keys=[z.key, y.key], compiler="identity_comp"
     )
     assert len(subgraphs) == 2
     for subgraph in subgraphs:
@@ -275,7 +275,7 @@ def test_compile_subgraphs_multiple_outputs(res):
     y = scale_func(x, 3.0)
     z = scale_func(y, 4.0)
 
-    compiler = res.compilers["identity"]
+    compiler = res.compilers["identity_comp"]
     optimized_dsk = mg_compiler.compile_subgraphs(
         z.__dask_graph__(), output_keys=[z.key, y.key], compiler=compiler
     )
@@ -292,7 +292,7 @@ def test_optimize(res):
     y = scale_func(x, 3.0)
     z = scale_func(y, 4.0)
 
-    compiler = res.compilers["identity"]
+    compiler = res.compilers["identity_comp"]
     optimized_dsk = mg_compiler.optimize(
         z.__dask_graph__(), output_keys=[z.key, y.key], compiler=compiler
     )
@@ -321,7 +321,7 @@ def test_automatic_optimize(res):
     y = scale_func(x, 3.0)
     z = scale_func(y, 4.0)
 
-    compiler = res.compilers["identity"]
+    compiler = res.compilers["identity_comp"]
 
     # expect 1 compiled chain
     compiler.clear_trace()
@@ -350,7 +350,7 @@ def res():
     def testing_add(a: Vector, b: Vector) -> Vector:  # pragma: no cover
         pass
 
-    @concrete_algorithm("testing.add", compiler="identity")
+    @concrete_algorithm("testing.add", compiler="identity_comp")
     def compiled_add(a: NumpyVectorType, b: NumpyVectorType) -> NumpyVectorType:
         return a + b
 
@@ -358,7 +358,7 @@ def res():
     def testing_scale(a: Vector, scale: float) -> Vector:  # pragma: no cover
         pass
 
-    @concrete_algorithm("testing.scale", compiler="identity")
+    @concrete_algorithm("testing.scale", compiler="identity_comp")
     def compiled_scale(a: NumpyVectorType, scale: float) -> NumpyVectorType:
         return a * scale
 
@@ -366,7 +366,7 @@ def res():
     def testing_offset(a: Vector, *, offset: float) -> Vector:  # pragma: no cover
         pass
 
-    @concrete_algorithm("testing.offset", compiler="identity")
+    @concrete_algorithm("testing.offset", compiler="identity_comp")
     def compiled_offset(a: NumpyVectorType, *, offset: float) -> NumpyVectorType:
         return a + offset
 

--- a/metagraph/tests/compiler/test_subgraphs.py
+++ b/metagraph/tests/compiler/test_subgraphs.py
@@ -307,7 +307,7 @@ def test_optimize_cull(res):
     merge = res.algos.testing.add(z1, z2)
     ans = scale_func(merge, 2.8)
 
-    compiler = res.compilers["identity"]
+    compiler = res.compilers["identity_comp"]
     optimized_dsk = mg_compiler.optimize(
         ans.__dask_graph__(), output_keys=[z2.key], compiler=compiler
     )

--- a/metagraph/tests/test_dask_visualize.py
+++ b/metagraph/tests/test_dask_visualize.py
@@ -1,0 +1,59 @@
+import numpy as np
+from dask.utils import tmpfile
+from metagraph.tests.compiler.test_subgraphs import res
+from metagraph.core.dask.visualize import visualize, merge_dict_of_dict
+
+
+def test_merge_dict_of_dict():
+    base = {"key1": {"attr1": 1, "attr2": 2}, "key2": {"attr1": 11, "attr3": 13,}}
+    overlay = {
+        "key1": {"attr1": 100, "attr3": 300,},
+        "key3": {"attr1": 1000, "attr4": 4000,},
+    }
+
+    result = merge_dict_of_dict(base, overlay)
+    expected = {
+        "key1": {"attr1": 100, "attr2": 2, "attr3": 300,},
+        "key2": {"attr1": 11, "attr3": 13,},
+        "key3": {"attr1": 1000, "attr4": 4000,},
+    }
+    assert result == expected
+
+
+def test_visualize(res):
+    a = np.arange(100)
+    scale_func = res.algos.testing.scale
+    z1 = scale_func(scale_func(scale_func(a, 2.0), 3.0), 4.0)
+    z2 = scale_func(scale_func(scale_func(a, 2.5), 3.5), 4.5)
+    merge = res.algos.testing.add(z1, z2)
+    ans = scale_func(merge, 2.8)
+
+    with tmpfile(extension="dot") as fn:
+        visualize(ans, filename=fn)
+        with open(fn) as f:
+            contents = f.read()
+        # this is an inadequate test, but at least confirms some basic are working
+        assert "testing.scale" in contents
+        assert "testing.add" in contents
+        assert "NumpyVectorType" in contents
+
+    with tmpfile(extension="dot") as fn:
+        visualize(ans, collapse_outputs=True, filename=fn)
+        with open(fn) as f:
+            contents = f.read()
+        assert "testing.scale" in contents
+        assert "testing.add" in contents
+        # data nodes should be hidden
+        assert "NumpyVectorType" not in contents
+
+
+def test_placeholder_visualize(res):
+    a = np.arange(100)
+    scale_func = res.algos.testing.scale
+    z1 = scale_func(scale_func(scale_func(a, 2.0), 3.0), 4.0)
+
+    with tmpfile(extension="dot") as fn:
+        z1.visualize(filename=fn)
+        with open(fn) as f:
+            contents = f.read()
+        assert "testing.scale" in contents

--- a/metagraph/tests/test_dask_visualize.py
+++ b/metagraph/tests/test_dask_visualize.py
@@ -57,3 +57,18 @@ def test_placeholder_visualize(res):
         with open(fn) as f:
             contents = f.read()
         assert "testing.scale" in contents
+
+
+def test_optimize_and_visualize(res):
+    a = np.arange(100)
+    scale_func = res.algos.testing.scale
+    z1 = scale_func(scale_func(scale_func(a, 2.0), 3.0), 4.0)
+    z2 = scale_func(scale_func(scale_func(a, 2.5), 3.5), 4.5)
+    merge = res.algos.testing.add(z1, z2)
+    ans = scale_func(merge, 2.8)
+
+    with tmpfile(extension="dot") as fn:
+        visualize(ans, filename=fn, optimize_graph=True)
+        with open(fn) as f:
+            contents = f.read()
+        assert "identity_comp fused" in contents

--- a/metagraph/tests/util.py
+++ b/metagraph/tests/util.py
@@ -315,7 +315,7 @@ class IdentityCompiler(TracingCompiler):
     """This compiler returns functions unchanged.
     """
 
-    def __init__(self, name="identity"):
+    def __init__(self, name="identity_comp"):
         super().__init__(name=name)
 
     def compile_algorithm(self, algo, literals):


### PR DESCRIPTION
(Based on #183, which should be merged first)

This adds a custom visualize method for Metagraph, based on Dask's visualize method.  A custom method allows us to:
* use node shapes which are friendlier to wide labels than `circle`
* Apply custom labels to different kinds of nodes easily without making really confusing task keys
* Use color and line width to highlight nodes of interest, like those that have been compiled or fused.

The customization is implemented by creating a dictionary of function and data attributes that is passed to the dask `visualize()` method.
