### PR TITLE
bind concrete algorithms and translators to resolver when registering

### DIFF
--- a/metagraph/core/compiler.py
+++ b/metagraph/core/compiler.py
@@ -149,7 +149,9 @@ def compile_subgraphs(dsk, output_keys, compiler: Compiler):
             source_algos = [task[0].algo for task in subgraph.tasks.values()]
             output_task = subgraph.tasks[subgraph.output_key]
             result_type = output_task[0].result_type
-            resolver = output_task[0].resolver
+            resolver = source_algos[
+                0
+            ].resolver  # assume all concrete algos were bound to same resolver
 
             # remove keys for existing tasks in subgraph, including the output task
             for key in subgraph.tasks:
@@ -194,7 +196,7 @@ def optimize(dsk, output_keys, **kwargs):
             if task_callable.algo._compiler is not None:
                 compiler_name = task_callable.algo._compiler
                 if compiler_name not in compilers:
-                    compilers[compiler_name] = task_callable.resolver.compilers[
+                    compilers[compiler_name] = task_callable.algo.resolver.compilers[
                         compiler_name
                     ]
 

--- a/metagraph/core/compiler.py
+++ b/metagraph/core/compiler.py
@@ -149,9 +149,6 @@ def compile_subgraphs(dsk, output_keys, compiler: Compiler):
             source_algos = [task[0].algo for task in subgraph.tasks.values()]
             output_task = subgraph.tasks[subgraph.output_key]
             result_type = output_task[0].result_type
-            resolver = source_algos[
-                0
-            ].resolver  # assume all concrete algos were bound to same resolver
 
             # remove keys for existing tasks in subgraph, including the output task
             for key in subgraph.tasks:
@@ -163,7 +160,6 @@ def compile_subgraphs(dsk, output_keys, compiler: Compiler):
                 compiler=compiler.name,
                 source_algos=source_algos,
                 result_type=result_type,
-                resolver=resolver,
             )
             new_dsk[subgraph.output_key] = (fused_task, *subgraph.input_keys)
         except CompileError as e:

--- a/metagraph/core/dask/placeholder.py
+++ b/metagraph/core/dask/placeholder.py
@@ -124,7 +124,7 @@ class Placeholder(DaskMethodsMixin):
             new_kwargs_flat.append([kw, val])
         # Add this func to the task graph
         if isinstance(func, ConcreteAlgorithm):
-            task_func = DelayedAlgo(func, result_type=result_type, resolver=resolver)
+            task_func = DelayedAlgo(func, result_type=result_type)
             dsk[key] = (task_func, new_args, (dict, new_kwargs_flat))
         elif isinstance(func, Translator):
             task_func = DelayedTranslate(

--- a/metagraph/core/dask/tasks.py
+++ b/metagraph/core/dask/tasks.py
@@ -20,17 +20,10 @@ class MetagraphTask:
 
 
 class DelayedAlgo(MetagraphTask):
-    def __init__(
-        self, algo: ConcreteAlgorithm, result_type: ConcreteType, resolver: "Resolver"
-    ):
+    def __init__(self, algo: ConcreteAlgorithm, result_type: ConcreteType):
         self.algo = algo
-        self.resolver = resolver
 
         def call(args, kwargs):
-            if algo._include_resolver or algo._compiler:
-                # do not mutate the kwargs
-                kwargs = kwargs.copy()
-                kwargs["resolver"] = resolver
             return algo(*args, **kwargs)
 
         super().__init__(callable=call, result_type=result_type)

--- a/metagraph/core/dask/tasks.py
+++ b/metagraph/core/dask/tasks.py
@@ -40,7 +40,6 @@ class DelayedJITAlgo(MetagraphTask):
         compiler: str,
         source_algos: List[ConcreteAlgorithm],
         result_type: ConcreteType,
-        resolver: "Resolver",
     ):
         self.source_algos = source_algos
         self.compiler = compiler

--- a/metagraph/core/plugin.py
+++ b/metagraph/core/plugin.py
@@ -510,12 +510,21 @@ class Translator:
 
     def __init__(self, func: Callable, include_resolver: bool):
         self.func = func
+        self.resolver = None
         self._include_resolver = include_resolver
         self.__name__ = func.__name__
         self.__doc__ = func.__doc__
         self.__wrapped__ = func
 
+    def copy_and_bind(self, resolver):
+        new_copy = copy.copy(self)
+        new_copy.resolver = resolver
+        return new_copy
+
     def __call__(self, src, *, resolver=None, **props):
+        if resolver is None:
+            resolver = self.resolver  # use bound resolver
+
         if self._include_resolver:
             if resolver is None:
                 raise ValueError("`resolver` is None, but is required by translator")

--- a/metagraph/core/plugin.py
+++ b/metagraph/core/plugin.py
@@ -611,8 +611,8 @@ class ConcreteAlgorithm:
         self.func = func
         self.abstract_name = abstract_name
         self.version = version
+        self.resolver = None
         self._include_resolver = include_resolver
-        self._resolver = None
         self._compiler = compiler
         self._compiled_func = None
         self.__name__ = func.__name__
@@ -623,13 +623,13 @@ class ConcreteAlgorithm:
 
     def copy_and_bind(self, resolver):
         new_copy = copy.copy(self)
-        new_copy._resolver = resolver
+        new_copy.resolver = resolver
         new_copy._compiled_func = None
         return new_copy
 
     def __call__(self, *args, resolver=None, **kwargs):
         if resolver is None:
-            resolver = self._resolver  # use bound resolver
+            resolver = self.resolver  # use bound resolver
 
         if self._compiler is not None:
             if self._compiled_func is not None:

--- a/metagraph/core/plugin.py
+++ b/metagraph/core/plugin.py
@@ -2,6 +2,7 @@
 """
 import types
 import inspect
+import copy
 from functools import partial
 from typing import Callable, List, Dict, Set, Union, Any, Optional
 from .typecache import TypeCache, TypeInfo
@@ -611,6 +612,7 @@ class ConcreteAlgorithm:
         self.abstract_name = abstract_name
         self.version = version
         self._include_resolver = include_resolver
+        self._resolver = None
         self._compiler = compiler
         self._compiled_func = None
         self.__name__ = func.__name__
@@ -619,7 +621,16 @@ class ConcreteAlgorithm:
         self.__original_signature__ = inspect.signature(self.func)
         self.__signature__ = normalize_signature(self.__original_signature__)
 
+    def copy_and_bind(self, resolver):
+        new_copy = copy.copy(self)
+        new_copy._resolver = resolver
+        new_copy._compiled_func = None
+        return new_copy
+
     def __call__(self, *args, resolver=None, **kwargs):
+        if resolver is None:
+            resolver = self._resolver  # use bound resolver
+
         if self._compiler is not None:
             if self._compiled_func is not None:
                 func = self._compiled_func

--- a/metagraph/core/resolver.py
+++ b/metagraph/core/resolver.py
@@ -589,8 +589,8 @@ class _ResolverRegistrar:
             items_by_plugin[plugin_name] = {}
             for cat in plugin_categories:
                 items = set(plugin.get(cat, ()))
-                if cat == "concrete_algorithms":
-                    # Copy concrete algorithms to avoid cross-mutation if multiple resolvers are used
+                if cat in ("concrete_algorithms", "translators"):
+                    # Copy to avoid cross-mutation if registered with multiple resolvers
                     items = {x.copy_and_bind(resolver) for x in items}
                 items_by_plugin[plugin_name][cat] = items
                 items_by_plugin["all"][cat] |= items

--- a/metagraph/core/resolver.py
+++ b/metagraph/core/resolver.py
@@ -591,7 +591,7 @@ class _ResolverRegistrar:
                 items = set(plugin.get(cat, ()))
                 if cat == "concrete_algorithms":
                     # Copy concrete algorithms to avoid cross-mutation if multiple resolvers are used
-                    items = {copy.copy(x) for x in items}
+                    items = {x.copy_and_bind(resolver) for x in items}
                 items_by_plugin[plugin_name][cat] = items
                 items_by_plugin["all"][cat] |= items
 

--- a/metagraph/tests/test_resolver.py
+++ b/metagraph/tests/test_resolver.py
@@ -584,8 +584,9 @@ def test_find_translator(example_resolver):
             assert len(trns.translators) == 1
             return trns.translators[0]
 
-    assert find_translator(4, StrNum.Type) == int_to_str
-    assert find_translator(StrNum("4"), IntType) == str_to_int
+    # cannot check Translator equality because of copy_and_bind() during registration
+    assert find_translator(4, StrNum.Type).func == int_to_str.func
+    assert find_translator(StrNum("4"), IntType).func == str_to_int.func
     assert find_translator(4, OtherType) is None
     assert find_translator(4, IntType) is None  # no self-translator registered
 


### PR DESCRIPTION
When registering a concrete algorithm or translator with a resolver, we already copy it, so now we can also bind the copied object to the resolver.  Then we don't have to worry about passing in a resolver when we call it later.  The `__call__()` method can automatically use the resolver if needed.

This PR is needed for metagraph-dev/metagraph-numba#1.