### PR TITLE
Fix for dtype changes in scipy==1.6.1

### DIFF
--- a/metagraph/plugins/scipy/algorithms.py
+++ b/metagraph/plugins/scipy/algorithms.py
@@ -1,5 +1,6 @@
 import warnings
 import numpy as np
+import metagraph as mg
 from metagraph import concrete_algorithm, NodeID
 from metagraph.plugins import has_scipy
 from .types import ScipyEdgeSet, ScipyEdgeMap, ScipyGraph
@@ -269,6 +270,8 @@ if has_scipy:
     @concrete_algorithm("util.graph.assign_uniform_weight")
     def ss_graph_assign_uniform_weight(graph: ScipyGraph, weight: Any) -> ScipyGraph:
         matrix = graph.value.copy()
+        dtype = mg.dtypes.dtype(type(weight))
+        matrix.data = matrix.data.astype(dtype)
         matrix.data.fill(weight)
         return ScipyGraph(matrix, graph.node_list, graph.node_vals)
 

--- a/metagraph/plugins/scipy/translators.py
+++ b/metagraph/plugins/scipy/translators.py
@@ -34,7 +34,7 @@ if has_scipy and has_networkx:
 
         weight = x.edge_weight_label if aprops["edge_type"] == "map" else None
         m = nx.convert_matrix.to_scipy_sparse_matrix(
-            x.value, nodelist=node_list, weight=weight,
+            x.value, nodelist=node_list, weight=weight, dtype=aprops["edge_dtype"]
         )
 
         return ScipyGraph(m, node_list, node_vals, aprops=aprops)


### PR DESCRIPTION
Scipy 1.6.1 has a bugfix which propagates dtypes for sparse data structures. Unfortunately, this somehow makes it default to float64 in the networkx conversion methods. To fix, explicitly pass the correct dtype.