### PR TITLE
Use setup-miniconda in github actions

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -10,25 +10,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.8
-      - name: Setup conda env
-        run: |
-          source "$CONDA/etc/profile.d/conda.sh"
-          conda config --set always_yes yes --set changeps1 no
-          conda update -q conda
-          conda env create -f continuous_integration/environment-3.8.yml
-          conda activate mg
-          pip install -e .
-      - name: Build PyPI artifacts
-        run: |
-          source "$CONDA/etc/profile.d/conda.sh"
-          conda activate mg
-          $CONDA/bin/python setup.py sdist bdist_wheel
+          auto-update-conda: true
+          activate-environment: mg
+          environment-file: continuous_integration/environment.yml
+      - run: pip install -e .
+      - run: $CONDA/bin/python setup.py sdist bdist_wheel
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -29,8 +29,6 @@ jobs:
           environment-file: continuous_integration/environment.yml
       - name: Update env
         run: |
-          conda config --set always_yes yes --set changeps1 no
-          conda info -a
           conda install -q conda-build
           pip install -e .
       - name: Lint with Black
@@ -89,7 +87,6 @@ jobs:
       - name: Update env
         shell: bash -l {0}
         run: |
-          conda config --set always_yes yes --set changeps1 no
           # Install built_packages
           cd ./artifact_storage
           tar -xvf output.tar
@@ -126,7 +123,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
       - name: Deploy to Anaconda Cloud
         run: |
-          conda install -q anaconda-client -y
+          conda install -q anaconda-client
           cd ./artifact_storage
           tar -xvf output.tar
           rm output.tar

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -13,43 +13,41 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Setup conda env
+      - name: Create env
+        uses: conda-incubator/setup-miniconda@v2
+          with:
+            auto-update-conda: true
+            activate-environment: mg
+            environment-file: continuous_integration/environment.yml
+      - name: Update env
         run: |
-          source "$CONDA/etc/profile.d/conda.sh"
           conda config --set always_yes yes --set changeps1 no
-          conda update -q conda
           conda info -a
           conda install -q conda-build
-          conda env create -f continuous_integration/environment.yml
-          conda activate mg
           pip install -e .
       - name: Lint with Black
         run: |
-          source "$CONDA/etc/profile.d/conda.sh"
-          conda activate mg
           black metagraph *.py --check --diff
       - name: Pytest
         run: |
-          source "$CONDA/etc/profile.d/conda.sh"
-          conda activate mg
           pytest metagraph
           pytest metagraph --dask --cov-append
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          source "$CONDA/etc/profile.d/conda.sh"
-          conda activate mg
           conda install -c conda-forge coveralls
           coveralls --service=github
       - name: Conda Build
         run: |
-          source "$CONDA/etc/profile.d/conda.sh"
           conda build -c defaults -c conda-forge --python 3.8 continuous_integration/conda
           # This doesn't rebuild, but simply computes the name of the file that was previously built
           OUTPUT=$(conda build --output -c defaults -c conda-forge --python 3.8 continuous_integration/conda)
@@ -83,13 +81,15 @@ jobs:
         with:
           name: built_package
           path: ./artifact_storage
-      - name: Setup conda env
+      - name: Create env
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.pyver }}
+      - name: Update env
+        shell: bash -l {0}
         run: |
-          source "$CONDA/etc/profile.d/conda.sh"
           conda config --set always_yes yes --set changeps1 no
-          conda update -q conda
-          conda create -n mg python=${{ matrix.pyver }}
-          conda activate mg
           # Install built_packages
           cd ./artifact_storage
           tar -xvf output.tar
@@ -101,9 +101,8 @@ jobs:
           conda update -c defaults -c conda-forge metagraph-dev
           conda list
       - name: Pytest
+        shell: bash -l {0}
         run: |
-          source "$CONDA/etc/profile.d/conda.sh"
-          conda activate mg
           python -m metagraph.tests
           python -m metagraph.tests --dask
 
@@ -123,11 +122,11 @@ jobs:
         if: contains(github.ref, 'refs/tags/')
         run: |
           echo "AC_LABEL=main" >> $GITHUB_ENV
+      - name: Create env
+        uses: conda-incubator/setup-miniconda@v2
       - name: Deploy to Anaconda Cloud
         run: |
-          source "$CONDA/etc/profile.d/conda.sh"
-          conda config --set always_yes yes --set changeps1 no
-          conda install -q anaconda-client
+          conda install -q anaconda-client -y
           cd ./artifact_storage
           tar -xvf output.tar
           rm output.tar

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -23,10 +23,10 @@ jobs:
           fetch-depth: 0
       - name: Create env
         uses: conda-incubator/setup-miniconda@v2
-          with:
-            auto-update-conda: true
-            activate-environment: mg
-            environment-file: continuous_integration/environment.yml
+        with:
+          auto-update-conda: true
+          activate-environment: mg
+          environment-file: continuous_integration/environment.yml
       - name: Update env
         run: |
           conda config --set always_yes yes --set changeps1 no


### PR DESCRIPTION
Word on the street is that conda-incubator/setup-miniconda is the way to go for GitHub Actions.