### PR TITLE
Skip roundtrip failures due to NotImplementedError

### DIFF
--- a/metagraph/core/dtypes.py
+++ b/metagraph/core/dtypes.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-bool = np.dtype(np.bool)
+bool = np.dtype(bool)
 int8 = np.dtype(np.int8)
 int16 = np.dtype(np.int16)
 int32 = np.dtype(np.int32)
@@ -17,7 +17,7 @@ complex64 = np.dtype(np.complex64)
 complex128 = np.dtype(np.complex128)
 datetime64 = np.dtype(np.datetime64)
 timedelta64 = np.dtype(np.timedelta64)
-object = np.dtype(np.object)
+object = np.dtype(object)
 
 _dtypes = [
     bool,

--- a/metagraph/plugins/scipy/translators.py
+++ b/metagraph/plugins/scipy/translators.py
@@ -4,7 +4,7 @@ import numpy as np
 
 if has_scipy:
     import scipy.sparse as ss
-    from .types import ScipyEdgeMap, ScipyEdgeSet
+    from .types import ScipyEdgeMap, ScipyEdgeSet, ScipyGraph
 
     @translator
     def edgemap_to_edgeset(x: ScipyEdgeMap, **props) -> ScipyEdgeSet:
@@ -17,7 +17,6 @@ if has_scipy:
 
 if has_scipy and has_networkx:
     import networkx as nx
-    from .types import ScipyGraph
     from ..networkx.types import NetworkXGraph
 
     @translator


### PR DESCRIPTION
mlir-graphblas doesn't support int dtypes. The translators in metagraph-mlir raise NotImplementedError for this case. To avoid this breaking tests, silently ignore NotImplementedError in the RoundTripper.

The rationale for this is that raising NotImplementedError will never give an invalid translation to the user, so it didn't fail a test. Instead, it simply indicates that a translator does not handle that specific input.

In the future, we need to handle translators in runtime raising NotImplementedError as part of a lazy evaluation path.