### PR TITLE
Update pagerank test to allow full convergence even with small maxiter

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -35,13 +35,10 @@ jobs:
         run: |
           black --version
           black metagraph *.py --check --diff
-          echo "SOME_TEST=metagraph --dask --cov-append" >> $GITHUB_ENV
       - name: Pytest
         run: |
           pytest metagraph
-          echo ${{ env.SOME_TEST }}
-          echo "Running test from env var containing spaces"
-          pytest ${{ env.SOME_TEST }}
+          pytest metagraph --dask --cov-append
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -124,7 +121,7 @@ jobs:
       - name: Determine label
         if: contains(github.ref, 'refs/tags/')
         run: |
-          echo "AC_LABEL='-l main -l dev'" >> $GITHUB_ENV
+          echo "AC_LABEL=-l main -l dev" >> $GITHUB_ENV
       - name: Deploy to Anaconda Cloud
         run: |
           conda install -q anaconda-client

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -35,10 +35,13 @@ jobs:
         run: |
           black --version
           black metagraph *.py --check --diff
+          echo "SOME_TEST=metagraph --dask --cov-append" >> $GITHUB_ENV
       - name: Pytest
         run: |
           pytest metagraph
-          pytest metagraph --dask --cov-append
+          echo ${{ env.SOME_TEST }}
+          echo "Running test from env var containing spaces"
+          pytest ${{ env.SOME_TEST }}
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
maxiter in pagerank has been a back-and-forth issue. Originally we allowed implementations to provide a best-effort result based on no more than maxiter iterations. Then we changed to requiring implementations to raise a ConvergenceError if they could not converge within maxiter iterations. Now we allow implementations to ignore maxiter and always converge, so long as they never provide an unconverged result. Implementations can still raise a ConvergenceError if maxiter is reached. This is the preferred approach, but both are acceptable.