### PR TITLE
Make metagraph.core.dask.loader.load_chunk's copying behavior robust against older versions of pandas

### DIFF
--- a/metagraph/core/dask/loader.py
+++ b/metagraph/core/dask/loader.py
@@ -390,7 +390,7 @@ def load_chunk(
 
     # we assume the records were already sorted by row number, but this ensures the column numbers are sorted within the row
     partition = partition.drop_duplicates(
-        [coo_desc.row_fieldname, coo_desc.col_fieldname]
+        [coo_desc.row_fieldname, coo_desc.col_fieldname], inplace=False
     )
     # We can sort in place because the previous operation copied the dataframe
     partition.sort_values(


### PR DESCRIPTION


When installing `metagraph` or some package depending on it via `conda` can occasionally lead to hard-to-predict behavior w.r.t which versions of dependencies are installed, e.g. I somehow ended up with version 1.2.5 of `pandas` installed, which makes `pandas.DataFrame.drop_duplicates` have a default value of `True` for the `inplace` arg.

This patch makes the use of `pandas.DataFrame.drop_duplicates` in `metagraph.core.dask.loader.load_chunk` explicitly set `inplace=False`.