### PR TITLE
Fix inplace error in metagraph.core.dask.loader.load_chunk

### DIFF
--- a/continuous_integration/conda/meta.yaml
+++ b/continuous_integration/conda/meta.yaml
@@ -20,10 +20,10 @@ requirements:
     - networkx >=2.5.1
     - pandas
     - python-louvain
-    - scipy
+    - scipy >=1.8.0
     - donfig
     - grblas >=1.3.5
-    - dask
+    - dask ==2021.10.0
     - python-graphviz
     - graphviz >=2.47
     - nest-asyncio

--- a/continuous_integration/environment.yml
+++ b/continuous_integration/environment.yml
@@ -9,12 +9,13 @@ dependencies:
   - python-graphviz
 
 # metagraph dependencies (so setup.py develop doesn't pip install them)
-  - dask
+  - dask==2021.10.0
   - numpy
   - networkx>=2.5.1
   - pandas
-  - scipy
+  - scipy>=1.8.0
   - scikit-learn
+  - conda-forge::distributed
   - conda-forge::donfig
   - conda-forge::grblas
   - conda-forge::python-louvain

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -25,9 +25,10 @@ dependencies:
   - numpy
   - networkx
   - pandas
-  - scipy
+  - scipy>=1.8.0
   - scikit-learn
-  - dask
+  - dask==2021.10.0
+  - conda-forge::distributed
   - conda-forge::donfig
   - conda-forge::grblas
   - conda-forge::python-louvain

--- a/metagraph/core/dask/loader.py
+++ b/metagraph/core/dask/loader.py
@@ -179,9 +179,7 @@ class SharedCSRLoader:
     @classmethod
     def register_dask_scheduler_plugin(cls, client: distributed.Client):
         plugin = SharedMemoryRefCounter(cls.REFCOUNT_TAG)
-        client.register_scheduler_plugin(
-            plugin, idempotent=True, name="metagraph_shared_csr_refcount"
-        )
+        client.register_scheduler_plugin(plugin, name="metagraph_shared_csr_refcount")
 
     @staticmethod
     def allocate(shape, nvalues, pointers_dtype, indices_dtype, values_dtype):
@@ -391,11 +389,7 @@ def load_chunk(
     # we assume the records were already sorted by row number, but this ensures the column numbers are sorted within the row
     partition = partition.drop_duplicates(
         [coo_desc.row_fieldname, coo_desc.col_fieldname]
-    )
-    # We can sort in place because the previous operation copied the dataframe
-    partition.sort_values(
-        by=[coo_desc.row_fieldname, coo_desc.col_fieldname], inplace=True
-    )
+    ).sort_values(by=[coo_desc.row_fieldname, coo_desc.col_fieldname])
 
     # compute pointer offsets
     rows = partition[coo_desc.row_fieldname].to_numpy()


### PR DESCRIPTION
When using `metagraph.core.dask.loader.load_chunk` with `dask-grblas`, warnings were coming up when we tried to sort the partition. They complained that we were editing views of the given dataframe. This PR intends to address those complaints.